### PR TITLE
Switch from US Core to base FHIR resources

### DIFF
--- a/input/fsh/examples_scenario1.fsh
+++ b/input/fsh/examples_scenario1.fsh
@@ -1,81 +1,81 @@
-////////////////////////////////////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Instance:   Scenario1Patient
-InstanceOf: VaccineCredentialPatient
-Title:      "Scenario 1: Example Patient"
-* identifier.use = #usual
-* identifier.type = http://terminology.hl7.org/CodeSystem/v2-0203#MR "Medical Record Number"
-* identifier.system = "http://hospital.example.org"
-* identifier.value = "m123"
-* name.family = "Anyperson"
-* name.given[0] = "John"
-* name.given[1] = "B."
-* contact.telecom[0].system = #phone
-* contact.telecom[0].value = "555-555-5555"
-* contact.telecom[0].use = #home
-* contact.telecom[1].system = #email
-* contact.telecom[1].value = "john.anyperson@example.com"
-* gender = #male
-* birthDate = "1951-01-20"
-* address.line = "123 Main St"
-* address.city = "Anytown"
-* address.postalCode = "12345"
-* address.country = "US"
-* communication.language = urn:ietf:bcp:47#en-US "English (Region=United States)"
-* communication.language.text = "English"
+// Instance:   Scenario1Patient
+// InstanceOf: VaccineCredentialPatient
+// Title:      "Scenario 1: Example Patient"
+// * identifier.use = #usual
+// * identifier.type = http://terminology.hl7.org/CodeSystem/v2-0203#MR "Medical Record Number"
+// * identifier.system = "http://hospital.example.org"
+// * identifier.value = "m123"
+// * name.family = "Anyperson"
+// * name.given[0] = "John"
+// * name.given[1] = "B."
+// * contact.telecom[0].system = #phone
+// * contact.telecom[0].value = "555-555-5555"
+// * contact.telecom[0].use = #home
+// * contact.telecom[1].system = #email
+// * contact.telecom[1].value = "john.anyperson@example.com"
+// * gender = #male
+// * birthDate = "1951-01-20"
+// * address.line = "123 Main St"
+// * address.city = "Anytown"
+// * address.postalCode = "12345"
+// * address.country = "US"
+// * communication.language = urn:ietf:bcp:47#en-US "English (Region=United States)"
+// * communication.language.text = "English"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Instance:   Scenario1Immunization1
-InstanceOf: VaccineCredentialImmunization
-Title:      "Scenario 1: Example Immunization 1"
-* status = #completed
-* vaccineCode = CVX#207 "COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5 mL dose"
-* patient = Reference(Scenario1Patient)
-* occurrenceDateTime = "2021-01-01T11:45:33+11:00"
-* primarySource = true
-* location = Reference(Scenario1Location)
-* lotNumber = "Lot #0000001"
-* protocolApplied.doseNumberPositiveInt = 1
-* protocolApplied.seriesDosesPositiveInt = 2
-* protocolApplied.targetDisease = SCT#840539006 "COVID-19"
+// Instance:   Scenario1Immunization1
+// InstanceOf: VaccineCredentialImmunization
+// Title:      "Scenario 1: Example Immunization 1"
+// * status = #completed
+// * vaccineCode = CVX#207 "COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5 mL dose"
+// * patient = Reference(Scenario1Patient)
+// * occurrenceDateTime = "2021-01-01T11:45:33+11:00"
+// * primarySource = true
+// * location = Reference(Scenario1Location)
+// * lotNumber = "Lot #0000001"
+// * protocolApplied.doseNumberPositiveInt = 1
+// * protocolApplied.seriesDosesPositiveInt = 2
+// * protocolApplied.targetDisease = SCT#840539006 "COVID-19"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Instance:   Scenario1Immunization2
-InstanceOf: VaccineCredentialImmunization
-Title:      "Scenario 1: Example Immunization 2"
-* status = #completed
-* vaccineCode = CVX#207 "COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5 mL dose"
-* patient = Reference(Scenario1Patient)
-* occurrenceDateTime = "2021-01-29T11:45:33+11:00"
-* primarySource = true
-* location = Reference(Scenario1Location)
-* lotNumber = "Lot #0000007"
-* protocolApplied.doseNumberPositiveInt = 2
-* protocolApplied.seriesDosesPositiveInt = 2
-* protocolApplied.targetDisease = SCT#840539006 "COVID-19"
+// Instance:   Scenario1Immunization2
+// InstanceOf: VaccineCredentialImmunization
+// Title:      "Scenario 1: Example Immunization 2"
+// * status = #completed
+// * vaccineCode = CVX#207 "COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5 mL dose"
+// * patient = Reference(Scenario1Patient)
+// * occurrenceDateTime = "2021-01-29T11:45:33+11:00"
+// * primarySource = true
+// * location = Reference(Scenario1Location)
+// * lotNumber = "Lot #0000007"
+// * protocolApplied.doseNumberPositiveInt = 2
+// * protocolApplied.seriesDosesPositiveInt = 2
+// * protocolApplied.targetDisease = SCT#840539006 "COVID-19"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Instance:   Scenario1Location
-InstanceOf: USCoreLocation
-Title:      "Scenario 1: Example Location"
-* name = "ABC Pharmacy"
+// Instance:   Scenario1Location
+// InstanceOf: USCoreLocation
+// Title:      "Scenario 1: Example Location"
+// * name = "ABC Pharmacy"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Instance:   Scenario1Bundle
-InstanceOf: VaccineCredentialBundle
-Title:      "Scenario 1: Example Bundle"
-* entry[+].resource = Scenario1Patient
-* entry[=].fullUrl = "http://example.org/fhir/Patient/Scenario1Patient"
+// Instance:   Scenario1Bundle
+// InstanceOf: VaccineCredentialBundle
+// Title:      "Scenario 1: Example Bundle"
+// * entry[+].resource = Scenario1Patient
+// * entry[=].fullUrl = "http://example.org/fhir/Patient/Scenario1Patient"
 
-* entry[+].resource = Scenario1Immunization1
-* entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario1Immunization1"
+// * entry[+].resource = Scenario1Immunization1
+// * entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario1Immunization1"
 
-* entry[+].resource = Scenario1Immunization2
-* entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario1Immunization2"
+// * entry[+].resource = Scenario1Immunization2
+// * entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario1Immunization2"
 
-* entry[+].resource = Scenario1Location
-* entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario1Location"
+// * entry[+].resource = Scenario1Location
+// * entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario1Location"

--- a/input/fsh/examples_scenario1.fsh
+++ b/input/fsh/examples_scenario1.fsh
@@ -1,81 +1,81 @@
-// ////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Instance:   Scenario1Patient
-// InstanceOf: VaccineCredentialPatient
-// Title:      "Scenario 1: Example Patient"
-// * identifier.use = #usual
-// * identifier.type = http://terminology.hl7.org/CodeSystem/v2-0203#MR "Medical Record Number"
-// * identifier.system = "http://hospital.example.org"
-// * identifier.value = "m123"
-// * name.family = "Anyperson"
-// * name.given[0] = "John"
-// * name.given[1] = "B."
-// * contact.telecom[0].system = #phone
-// * contact.telecom[0].value = "555-555-5555"
-// * contact.telecom[0].use = #home
-// * contact.telecom[1].system = #email
-// * contact.telecom[1].value = "john.anyperson@example.com"
-// * gender = #male
-// * birthDate = "1951-01-20"
-// * address.line = "123 Main St"
-// * address.city = "Anytown"
-// * address.postalCode = "12345"
-// * address.country = "US"
-// * communication.language = urn:ietf:bcp:47#en-US "English (Region=United States)"
-// * communication.language.text = "English"
+Instance:   Scenario1Patient
+InstanceOf: VaccineCredentialPatient
+Title:      "Scenario 1: Example Patient"
+* identifier.use = #usual
+* identifier.type = http://terminology.hl7.org/CodeSystem/v2-0203#MR "Medical Record Number"
+* identifier.system = "http://hospital.example.org"
+* identifier.value = "m123"
+* name.family = "Anyperson"
+* name.given[0] = "John"
+* name.given[1] = "B."
+* contact.telecom[0].system = #phone
+* contact.telecom[0].value = "555-555-5555"
+* contact.telecom[0].use = #home
+* contact.telecom[1].system = #email
+* contact.telecom[1].value = "john.anyperson@example.com"
+* gender = #male
+* birthDate = "1951-01-20"
+* address.line = "123 Main St"
+* address.city = "Anytown"
+* address.postalCode = "12345"
+* address.country = "US"
+* communication.language = urn:ietf:bcp:47#en-US "English (Region=United States)"
+* communication.language.text = "English"
 
-// ////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Instance:   Scenario1Immunization1
-// InstanceOf: VaccineCredentialImmunization
-// Title:      "Scenario 1: Example Immunization 1"
-// * status = #completed
-// * vaccineCode = CVX#207 "COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5 mL dose"
-// * patient = Reference(Scenario1Patient)
-// * occurrenceDateTime = "2021-01-01T11:45:33+11:00"
-// * primarySource = true
-// * location = Reference(Scenario1Location)
-// * lotNumber = "Lot #0000001"
-// * protocolApplied.doseNumberPositiveInt = 1
-// * protocolApplied.seriesDosesPositiveInt = 2
-// * protocolApplied.targetDisease = SCT#840539006 "COVID-19"
+Instance:   Scenario1Immunization1
+InstanceOf: VaccineCredentialImmunization
+Title:      "Scenario 1: Example Immunization 1"
+* status = #completed
+* vaccineCode = CVX#207 "COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5 mL dose"
+* patient = Reference(Scenario1Patient)
+* occurrenceDateTime = "2021-01-01T11:45:33+11:00"
+* primarySource = true
+* location = Reference(Scenario1Location)
+* lotNumber = "Lot #0000001"
+* protocolApplied.doseNumberPositiveInt = 1
+* protocolApplied.seriesDosesPositiveInt = 2
+* protocolApplied.targetDisease = SCT#840539006 "COVID-19"
 
-// ////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Instance:   Scenario1Immunization2
-// InstanceOf: VaccineCredentialImmunization
-// Title:      "Scenario 1: Example Immunization 2"
-// * status = #completed
-// * vaccineCode = CVX#207 "COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5 mL dose"
-// * patient = Reference(Scenario1Patient)
-// * occurrenceDateTime = "2021-01-29T11:45:33+11:00"
-// * primarySource = true
-// * location = Reference(Scenario1Location)
-// * lotNumber = "Lot #0000007"
-// * protocolApplied.doseNumberPositiveInt = 2
-// * protocolApplied.seriesDosesPositiveInt = 2
-// * protocolApplied.targetDisease = SCT#840539006 "COVID-19"
+Instance:   Scenario1Immunization2
+InstanceOf: VaccineCredentialImmunization
+Title:      "Scenario 1: Example Immunization 2"
+* status = #completed
+* vaccineCode = CVX#207 "COVID-19, mRNA, LNP-S, PF, 100 mcg/0.5 mL dose"
+* patient = Reference(Scenario1Patient)
+* occurrenceDateTime = "2021-01-29T11:45:33+11:00"
+* primarySource = true
+* location = Reference(Scenario1Location)
+* lotNumber = "Lot #0000007"
+* protocolApplied.doseNumberPositiveInt = 2
+* protocolApplied.seriesDosesPositiveInt = 2
+* protocolApplied.targetDisease = SCT#840539006 "COVID-19"
 
-// ////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Instance:   Scenario1Location
-// InstanceOf: USCoreLocation
-// Title:      "Scenario 1: Example Location"
-// * name = "ABC Pharmacy"
+Instance:   Scenario1Location
+InstanceOf: USCoreLocation
+Title:      "Scenario 1: Example Location"
+* name = "ABC Pharmacy"
 
-// ////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Instance:   Scenario1Bundle
-// InstanceOf: VaccineCredentialBundle
-// Title:      "Scenario 1: Example Bundle"
-// * entry[+].resource = Scenario1Patient
-// * entry[=].fullUrl = "http://example.org/fhir/Patient/Scenario1Patient"
+Instance:   Scenario1Bundle
+InstanceOf: VaccineCredentialBundle
+Title:      "Scenario 1: Example Bundle"
+* entry[+].resource = Scenario1Patient
+* entry[=].fullUrl = "http://example.org/fhir/Patient/Scenario1Patient"
 
-// * entry[+].resource = Scenario1Immunization1
-// * entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario1Immunization1"
+* entry[+].resource = Scenario1Immunization1
+* entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario1Immunization1"
 
-// * entry[+].resource = Scenario1Immunization2
-// * entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario1Immunization2"
+* entry[+].resource = Scenario1Immunization2
+* entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario1Immunization2"
 
-// * entry[+].resource = Scenario1Location
-// * entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario1Location"
+* entry[+].resource = Scenario1Location
+* entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario1Location"

--- a/input/fsh/examples_scenario1.fsh
+++ b/input/fsh/examples_scenario1.fsh
@@ -3,10 +3,6 @@
 Instance:   Scenario1Patient
 InstanceOf: VaccineCredentialPatient
 Title:      "Scenario 1: Example Patient"
-* identifier.use = #usual
-* identifier.type = http://terminology.hl7.org/CodeSystem/v2-0203#MR "Medical Record Number"
-* identifier.system = "http://hospital.example.org"
-* identifier.value = "m123"
 * name.family = "Anyperson"
 * name.given[0] = "John"
 * name.given[1] = "B."

--- a/input/fsh/examples_scenario2.fsh
+++ b/input/fsh/examples_scenario2.fsh
@@ -3,10 +3,6 @@
 Instance:   Scenario2Patient
 InstanceOf: VaccineCredentialPatient
 Title:      "Scenario 2: Example Patient"
-* identifier.use = #usual
-* identifier.type = http://terminology.hl7.org/CodeSystem/v2-0203#MR "Medical Record Number"
-* identifier.system = "http://hospital.example.org"
-* identifier.value = "m421"
 * name.family = "Anyperson"
 * name.given[0] = "Jane"
 * name.given[1] = "C."

--- a/input/fsh/examples_scenario2.fsh
+++ b/input/fsh/examples_scenario2.fsh
@@ -1,81 +1,81 @@
-////////////////////////////////////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Instance:   Scenario2Patient
-InstanceOf: VaccineCredentialPatient
-Title:      "Scenario 2: Example Patient"
-* identifier.use = #usual
-* identifier.type = http://terminology.hl7.org/CodeSystem/v2-0203#MR "Medical Record Number"
-* identifier.system = "http://hospital.example.org"
-* identifier.value = "m421"
-* name.family = "Anyperson"
-* name.given[0] = "Jane"
-* name.given[1] = "C."
-* contact.telecom[0].system = #phone
-* contact.telecom[0].value = "555-555-5555"
-* contact.telecom[0].use = #home
-* contact.telecom[1].system = #email
-* contact.telecom[1].value = "jane.anyperson@example.com"
-* gender = #male
-* birthDate = "1961-01-20"
-* address.line = "321 State St"
-* address.city = "Somecity"
-* address.postalCode = "12345"
-* address.country = "US"
-* communication.language = urn:ietf:bcp:47#en-US "English (Region=United States)"
-* communication.language.text = "English"
+// Instance:   Scenario2Patient
+// InstanceOf: VaccineCredentialPatient
+// Title:      "Scenario 2: Example Patient"
+// * identifier.use = #usual
+// * identifier.type = http://terminology.hl7.org/CodeSystem/v2-0203#MR "Medical Record Number"
+// * identifier.system = "http://hospital.example.org"
+// * identifier.value = "m421"
+// * name.family = "Anyperson"
+// * name.given[0] = "Jane"
+// * name.given[1] = "C."
+// * contact.telecom[0].system = #phone
+// * contact.telecom[0].value = "555-555-5555"
+// * contact.telecom[0].use = #home
+// * contact.telecom[1].system = #email
+// * contact.telecom[1].value = "jane.anyperson@example.com"
+// * gender = #male
+// * birthDate = "1961-01-20"
+// * address.line = "321 State St"
+// * address.city = "Somecity"
+// * address.postalCode = "12345"
+// * address.country = "US"
+// * communication.language = urn:ietf:bcp:47#en-US "English (Region=United States)"
+// * communication.language.text = "English"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Instance:   Scenario2Immunization1
-InstanceOf: VaccineCredentialImmunization
-Title:      "Scenario 2: Example Immunization 1"
-* status = #completed
-* vaccineCode = CVX#208 "COVID-19, mRNA, LNP-S, PF, 30 mcg/0.3 mL dose"
-* patient = Reference(Scenario2Patient)
-* occurrenceDateTime = "2021-01-01T11:45:33+11:00"
-* primarySource = true
-* location = Reference(Scenario2Location)
-* lotNumber = "Lot #0000001"
-* protocolApplied.doseNumberPositiveInt = 1
-* protocolApplied.seriesDosesPositiveInt = 2
-* protocolApplied.targetDisease = SCT#840539006 "COVID-19"
+// Instance:   Scenario2Immunization1
+// InstanceOf: VaccineCredentialImmunization
+// Title:      "Scenario 2: Example Immunization 1"
+// * status = #completed
+// * vaccineCode = CVX#208 "COVID-19, mRNA, LNP-S, PF, 30 mcg/0.3 mL dose"
+// * patient = Reference(Scenario2Patient)
+// * occurrenceDateTime = "2021-01-01T11:45:33+11:00"
+// * primarySource = true
+// * location = Reference(Scenario2Location)
+// * lotNumber = "Lot #0000001"
+// * protocolApplied.doseNumberPositiveInt = 1
+// * protocolApplied.seriesDosesPositiveInt = 2
+// * protocolApplied.targetDisease = SCT#840539006 "COVID-19"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Instance:   Scenario2Immunization2
-InstanceOf: VaccineCredentialImmunization
-Title:      "Scenario 2: Example Immunization 2"
-* status = #completed
-* vaccineCode = CVX#208 "COVID-19, mRNA, LNP-S, PF, 30 mcg/0.3 mL dose"
-* patient = Reference(Scenario2Patient)
-* occurrenceDateTime = "2021-01-29T11:45:33+11:00"
-* primarySource = true
-* location = Reference(Scenario2Location)
-* lotNumber = "Lot #0000007"
-* protocolApplied.doseNumberPositiveInt = 2
-* protocolApplied.seriesDosesPositiveInt = 2
-* protocolApplied.targetDisease = SCT#840539006 "COVID-19"
+// Instance:   Scenario2Immunization2
+// InstanceOf: VaccineCredentialImmunization
+// Title:      "Scenario 2: Example Immunization 2"
+// * status = #completed
+// * vaccineCode = CVX#208 "COVID-19, mRNA, LNP-S, PF, 30 mcg/0.3 mL dose"
+// * patient = Reference(Scenario2Patient)
+// * occurrenceDateTime = "2021-01-29T11:45:33+11:00"
+// * primarySource = true
+// * location = Reference(Scenario2Location)
+// * lotNumber = "Lot #0000007"
+// * protocolApplied.doseNumberPositiveInt = 2
+// * protocolApplied.seriesDosesPositiveInt = 2
+// * protocolApplied.targetDisease = SCT#840539006 "COVID-19"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Instance:   Scenario2Location
-InstanceOf: USCoreLocation
-Title:      "Scenario 2: Example Location"
-* name = "ABC Pharmacy"
+// Instance:   Scenario2Location
+// InstanceOf: USCoreLocation
+// Title:      "Scenario 2: Example Location"
+// * name = "ABC Pharmacy"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Instance:   Scenario2Bundle
-InstanceOf: VaccineCredentialBundle
-Title:      "Scenario 2: Example Bundle"
-* entry[+].resource = Scenario2Patient
-* entry[=].fullUrl = "http://example.org/fhir/Patient/Scenario2Patient"
+// Instance:   Scenario2Bundle
+// InstanceOf: VaccineCredentialBundle
+// Title:      "Scenario 2: Example Bundle"
+// * entry[+].resource = Scenario2Patient
+// * entry[=].fullUrl = "http://example.org/fhir/Patient/Scenario2Patient"
 
-* entry[+].resource = Scenario2Immunization1
-* entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario2Immunization1"
+// * entry[+].resource = Scenario2Immunization1
+// * entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario2Immunization1"
 
-* entry[+].resource = Scenario2Immunization2
-* entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario2Immunization2"
+// * entry[+].resource = Scenario2Immunization2
+// * entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario2Immunization2"
 
-* entry[+].resource = Scenario2Location
-* entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario2Location"
+// * entry[+].resource = Scenario2Location
+// * entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario2Location"

--- a/input/fsh/examples_scenario2.fsh
+++ b/input/fsh/examples_scenario2.fsh
@@ -1,81 +1,81 @@
-// ////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Instance:   Scenario2Patient
-// InstanceOf: VaccineCredentialPatient
-// Title:      "Scenario 2: Example Patient"
-// * identifier.use = #usual
-// * identifier.type = http://terminology.hl7.org/CodeSystem/v2-0203#MR "Medical Record Number"
-// * identifier.system = "http://hospital.example.org"
-// * identifier.value = "m421"
-// * name.family = "Anyperson"
-// * name.given[0] = "Jane"
-// * name.given[1] = "C."
-// * contact.telecom[0].system = #phone
-// * contact.telecom[0].value = "555-555-5555"
-// * contact.telecom[0].use = #home
-// * contact.telecom[1].system = #email
-// * contact.telecom[1].value = "jane.anyperson@example.com"
-// * gender = #male
-// * birthDate = "1961-01-20"
-// * address.line = "321 State St"
-// * address.city = "Somecity"
-// * address.postalCode = "12345"
-// * address.country = "US"
-// * communication.language = urn:ietf:bcp:47#en-US "English (Region=United States)"
-// * communication.language.text = "English"
+Instance:   Scenario2Patient
+InstanceOf: VaccineCredentialPatient
+Title:      "Scenario 2: Example Patient"
+* identifier.use = #usual
+* identifier.type = http://terminology.hl7.org/CodeSystem/v2-0203#MR "Medical Record Number"
+* identifier.system = "http://hospital.example.org"
+* identifier.value = "m421"
+* name.family = "Anyperson"
+* name.given[0] = "Jane"
+* name.given[1] = "C."
+* contact.telecom[0].system = #phone
+* contact.telecom[0].value = "555-555-5555"
+* contact.telecom[0].use = #home
+* contact.telecom[1].system = #email
+* contact.telecom[1].value = "jane.anyperson@example.com"
+* gender = #male
+* birthDate = "1961-01-20"
+* address.line = "321 State St"
+* address.city = "Somecity"
+* address.postalCode = "12345"
+* address.country = "US"
+* communication.language = urn:ietf:bcp:47#en-US "English (Region=United States)"
+* communication.language.text = "English"
 
-// ////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Instance:   Scenario2Immunization1
-// InstanceOf: VaccineCredentialImmunization
-// Title:      "Scenario 2: Example Immunization 1"
-// * status = #completed
-// * vaccineCode = CVX#208 "COVID-19, mRNA, LNP-S, PF, 30 mcg/0.3 mL dose"
-// * patient = Reference(Scenario2Patient)
-// * occurrenceDateTime = "2021-01-01T11:45:33+11:00"
-// * primarySource = true
-// * location = Reference(Scenario2Location)
-// * lotNumber = "Lot #0000001"
-// * protocolApplied.doseNumberPositiveInt = 1
-// * protocolApplied.seriesDosesPositiveInt = 2
-// * protocolApplied.targetDisease = SCT#840539006 "COVID-19"
+Instance:   Scenario2Immunization1
+InstanceOf: VaccineCredentialImmunization
+Title:      "Scenario 2: Example Immunization 1"
+* status = #completed
+* vaccineCode = CVX#208 "COVID-19, mRNA, LNP-S, PF, 30 mcg/0.3 mL dose"
+* patient = Reference(Scenario2Patient)
+* occurrenceDateTime = "2021-01-01T11:45:33+11:00"
+* primarySource = true
+* location = Reference(Scenario2Location)
+* lotNumber = "Lot #0000001"
+* protocolApplied.doseNumberPositiveInt = 1
+* protocolApplied.seriesDosesPositiveInt = 2
+* protocolApplied.targetDisease = SCT#840539006 "COVID-19"
 
-// ////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Instance:   Scenario2Immunization2
-// InstanceOf: VaccineCredentialImmunization
-// Title:      "Scenario 2: Example Immunization 2"
-// * status = #completed
-// * vaccineCode = CVX#208 "COVID-19, mRNA, LNP-S, PF, 30 mcg/0.3 mL dose"
-// * patient = Reference(Scenario2Patient)
-// * occurrenceDateTime = "2021-01-29T11:45:33+11:00"
-// * primarySource = true
-// * location = Reference(Scenario2Location)
-// * lotNumber = "Lot #0000007"
-// * protocolApplied.doseNumberPositiveInt = 2
-// * protocolApplied.seriesDosesPositiveInt = 2
-// * protocolApplied.targetDisease = SCT#840539006 "COVID-19"
+Instance:   Scenario2Immunization2
+InstanceOf: VaccineCredentialImmunization
+Title:      "Scenario 2: Example Immunization 2"
+* status = #completed
+* vaccineCode = CVX#208 "COVID-19, mRNA, LNP-S, PF, 30 mcg/0.3 mL dose"
+* patient = Reference(Scenario2Patient)
+* occurrenceDateTime = "2021-01-29T11:45:33+11:00"
+* primarySource = true
+* location = Reference(Scenario2Location)
+* lotNumber = "Lot #0000007"
+* protocolApplied.doseNumberPositiveInt = 2
+* protocolApplied.seriesDosesPositiveInt = 2
+* protocolApplied.targetDisease = SCT#840539006 "COVID-19"
 
-// ////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Instance:   Scenario2Location
-// InstanceOf: USCoreLocation
-// Title:      "Scenario 2: Example Location"
-// * name = "ABC Pharmacy"
+Instance:   Scenario2Location
+InstanceOf: USCoreLocation
+Title:      "Scenario 2: Example Location"
+* name = "ABC Pharmacy"
 
-// ////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Instance:   Scenario2Bundle
-// InstanceOf: VaccineCredentialBundle
-// Title:      "Scenario 2: Example Bundle"
-// * entry[+].resource = Scenario2Patient
-// * entry[=].fullUrl = "http://example.org/fhir/Patient/Scenario2Patient"
+Instance:   Scenario2Bundle
+InstanceOf: VaccineCredentialBundle
+Title:      "Scenario 2: Example Bundle"
+* entry[+].resource = Scenario2Patient
+* entry[=].fullUrl = "http://example.org/fhir/Patient/Scenario2Patient"
 
-// * entry[+].resource = Scenario2Immunization1
-// * entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario2Immunization1"
+* entry[+].resource = Scenario2Immunization1
+* entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario2Immunization1"
 
-// * entry[+].resource = Scenario2Immunization2
-// * entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario2Immunization2"
+* entry[+].resource = Scenario2Immunization2
+* entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario2Immunization2"
 
-// * entry[+].resource = Scenario2Location
-// * entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario2Location"
+* entry[+].resource = Scenario2Location
+* entry[=].fullUrl = "http://example.org/fhir/Immunization/Scenario2Location"

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -2,12 +2,30 @@
 
 Profile:     VaccineCredentialPatient
 Id:          vaccine-credential-patient
-Parent:      USCorePatientProfile
+// Parent:      USCorePatientProfile
+Parent:      Patient
 Title:       "Patient Profile"
 Description: "***Currently this profile does not modify USCorePatientProfile, and can be removed if
                 USCorePatientProfile is sufficient for our use cases.***"
 
 * ^status = #draft
+* identifier 0..0 // changed cardinality
+// active: not MS, no change in cardinality
+* name 1..* MS // changed cardinality to 1..*, added MS
+// telecom: not MS, no change in cardinality
+* gender 0..1 MS // added MS
+* birthDate 0..1 MS // added MS
+// deceased: not MS, no change in cardinality
+// address: not MS, no change in cardinality
+// maritalStatus: not MS, no change in cardinality
+// multipleBirth[x]: not MS, no change in cardinaltiy
+// photo: not MS, no change in cardinality
+// contact: not MS, no change in cardinality
+// communication: not MS, no change in cardinality
+// generalPractitioner: not MS, no change in cardinality
+// managingOrganization: not MS, no change in cardinality
+// link: not MS, no change in cardinality
+
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -9,11 +9,21 @@ Title:       "Patient Profile"
 Description: "Slight modification of Patient, with identifier as 0..0 and limited MS."
 
 * ^status = #draft
-* identifier 0..0 
-* name 1..* MS 
-* gender 0..1 MS 
+* identifier 0..0
+* identifier ^definition = "Identifer is not allowed in this IG due to risk of accidental, unnecessary exposure of sensitive identifiers to verifiers."
+* name 1..*
+* name and name.given and name.family MS
+* name obeys name-invariant
+* gender MS
 * gender from http://hl7.org/fhir/ValueSet/administrative-gender (required)
-* birthDate 0..1 MS 
+* birthDate MS
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+Invariant: name-invariant
+Description: "Require one of the key name elements to be filled. Allows for `text` for [names that cannot be cleanly categorized into `family` or `given`](https://www.nature.com/articles/d41586-020-02761-z)."
+Expression: "family.exists() or given.exists() or text.exists()"
+Severity: #error
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -18,8 +18,7 @@ Description: "***Slight modification of Patient, with identifier as 0..0 and lim
 
 Profile:     VaccineCredentialImmunization
 Id:          vaccine-credential-immunization
-Parent:  Immunization
-//Parent:      http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization
+Parent:      Immunization
 Title:       "Immunization Profile"
 Description: "Defines a profile representing a vaccination for a vaccine credential Health Card."
 
@@ -70,7 +69,6 @@ Severity:    #error
 
 Profile:        VaccineCredentialImmuneStatus
 Parent:         Observation
-// Parent:         USCoreLaboratoryResultObservationProfile
 Id:             vaccine-credential-immune-status
 Title:          "Immune Status Profile"
 Description:    "Defines constraints and extensions on the observation resource for the minimal set of data to query and retrieve vaccine credential immune status."

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -6,7 +6,7 @@ Profile:     VaccineCredentialPatient
 Id:          vaccine-credential-patient
 Parent:      Patient
 Title:       "Patient Profile"
-Description: "***Slight modification of Patient, with identifier as 0..0 and limited MS.***"
+Description: "Slight modification of Patient, with identifier as 0..0 and limited MS."
 
 * ^status = #draft
 * identifier 0..0 

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -1,3 +1,5 @@
+Alias:   ObsCat = http://terminology.hl7.org/CodeSystem/observation-category
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 Profile:     VaccineCredentialPatient
@@ -72,8 +74,11 @@ Parent:         Observation
 Id:             vaccine-credential-immune-status
 Title:          "Immune Status Profile"
 Description:    "Defines constraints and extensions on the observation resource for the minimal set of data to query and retrieve vaccine credential immune status."
+
 * ^status = #draft
 
+* category = ObsCat#laboratory
+* code 1..1 MS
 * subject only Reference(VaccineCredentialPatient)
 * effective[x] 1..1 MS
 * effective[x] only dateTime

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -25,6 +25,7 @@ Description: "***Currently this profile does not modify USCorePatientProfile, an
 // generalPractitioner: not MS, no change in cardinality
 // managingOrganization: not MS, no change in cardinality
 // link: not MS, no change in cardinality
+// left off us-core-race, us-core-ethnicity, us-core-birthsex
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -9,13 +9,19 @@ Title:       "Patient Profile"
 Description: "Slight modification of Patient, with identifier as 0..0 and limited MS."
 
 * ^status = #draft
+
 * identifier 0..0
 * identifier ^definition = "Identifer is not allowed in this IG due to risk of accidental, unnecessary exposure of sensitive identifiers to verifiers."
+
 * name 1..*
 * name and name.given and name.family MS
 * name obeys name-invariant
+
+// Keeping gender MS as it is likely available and useful for interfacing with IIS
+// See https://github.com/dvci/vaccine-credential-ig/pull/31#issuecomment-773434836 for details
 * gender MS
 * gender from http://hl7.org/fhir/ValueSet/administrative-gender (required)
+
 * birthDate MS
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -2,31 +2,15 @@
 
 Profile:     VaccineCredentialPatient
 Id:          vaccine-credential-patient
-// Parent:      USCorePatientProfile
 Parent:      Patient
 Title:       "Patient Profile"
-Description: "***Currently this profile does not modify USCorePatientProfile, and can be removed if
-                USCorePatientProfile is sufficient for our use cases.***"
+Description: "***Slight modification of Patient, with identifier as 0..0 and limited MS.***"
 
 * ^status = #draft
-* identifier 0..0 // changed cardinality
-// active: not MS, no change in cardinality
-* name 1..* MS // changed cardinality to 1..*, added MS
-// telecom: not MS, no change in cardinality
-* gender 0..1 MS // added MS
-* birthDate 0..1 MS // added MS
-// deceased: not MS, no change in cardinality
-// address: not MS, no change in cardinality
-// maritalStatus: not MS, no change in cardinality
-// multipleBirth[x]: not MS, no change in cardinaltiy
-// photo: not MS, no change in cardinality
-// contact: not MS, no change in cardinality
-// communication: not MS, no change in cardinality
-// generalPractitioner: not MS, no change in cardinality
-// managingOrganization: not MS, no change in cardinality
-// link: not MS, no change in cardinality
-// left off us-core-race, us-core-ethnicity, us-core-birthsex
-
+* identifier 0..0 
+* name 1..* MS 
+* gender 0..1 MS 
+* birthDate 0..1 MS 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -24,6 +24,8 @@ Description: "Defines a profile representing a vaccination for a vaccine credent
 * ^status = #draft
 
 * patient only Reference(VaccineCredentialPatient)
+* vaccineCode MS
+* occurrence[x] MS
 
 // Parent profile short description is not as clear as it could be
 * primarySource ^short = "Information in this record from person who administered vaccine?"

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -12,6 +12,7 @@ Description: "Slight modification of Patient, with identifier as 0..0 and limite
 * identifier 0..0 
 * name 1..* MS 
 * gender 0..1 MS 
+* gender from http://hl7.org/fhir/ValueSet/administrative-gender (required)
 * birthDate 0..1 MS 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -16,13 +16,14 @@ Description: "***Slight modification of Patient, with identifier as 0..0 and lim
 
 Profile:     VaccineCredentialImmunization
 Id:          vaccine-credential-immunization
-Parent:      http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization
+Parent:  Immunization
+//Parent:      http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization
 Title:       "Immunization Profile"
 Description: "Defines a profile representing a vaccination for a vaccine credential Health Card."
 
 * ^status = #draft
 
-* patient only Reference(USCorePatientProfile)
+* patient only Reference(VaccineCredentialPatient)
 
 // Parent profile short description is not as clear as it could be
 * primarySource ^short = "Information in this record from person who administered vaccine?"
@@ -64,13 +65,14 @@ Severity:    #error
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 Profile:        VaccineCredentialImmuneStatus
-Parent:         USCoreLaboratoryResultObservationProfile
+Parent:         Observation
+// Parent:         USCoreLaboratoryResultObservationProfile
 Id:             vaccine-credential-immune-status
 Title:          "Immune Status Profile"
 Description:    "Defines constraints and extensions on the observation resource for the minimal set of data to query and retrieve vaccine credential immune status."
 * ^status = #draft
 
-* subject only Reference(USCorePatientProfile)
+* subject only Reference(VaccineCredentialPatient)
 * effective[x] 1..1 MS
 * effective[x] only dateTime
 * effective[x] ^short = "When immune status was assessed"


### PR DESCRIPTION
Moves from using US Core profiles as the basis for our Immunization and Immune Status profiles to base FHIR resources. This is necessary because US Core requires us to include elements that we want to set to `0..0`.

Resolves #17, resolves #11