### PR TITLE
Fix CVX system to http://hl7.org/fhir/sid/cvx

### DIFF
--- a/input/fsh/value_sets.fsh
+++ b/input/fsh/value_sets.fsh
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Alias: CVX = https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.113883.12.292
+Alias: CVX = http://hl7.org/fhir/sid/cvx
 Alias: LNC = http://loinc.org
 Alias: SCT = http://snomed.info/sct
 Alias: ACT = http://terminology.hl7.org/CodeSystem/v3-ActReason


### PR DESCRIPTION
I'm not sure where the `https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.113883.12.292` URL came from when https://github.com/dvci/vaccine-credential-ig/commit/523de92eb3df9d83bc7f061f8395a8a3b432988d was merged.

https://www.hl7.org/fhir/cvx.html and US core both use `http://hl7.org/fhir/sid/cvx` as the FHIR `Coding.system` for CVX which I'm pretty sure is correct.