### PR TITLE
Improve isSubpotent docs and add invariant

### DIFF
--- a/input/fsh/invariants.fsh
+++ b/input/fsh/invariants.fsh
@@ -44,3 +44,17 @@ Invariant:   date-invariant
 Description: "All timestamps SHOULD be represented as Dates (YYYY-MM-DD only)."
 Expression:  "$this.toString().matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}$')"
 Severity:    #warning
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+Invariant:   should-be-true-if-populated-invariant
+Description: "Should be `true` if populated"
+Expression:  "$this.exists().not() or $this = true"
+Severity:    #warning
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+Invariant:   shall-be-true-if-populated-invariant
+Description: "Shall be `true` if populated"
+Expression:  "$this.exists().not() or $this = true"
+Severity:    #error

--- a/input/fsh/invariants.fsh
+++ b/input/fsh/invariants.fsh
@@ -47,13 +47,6 @@ Severity:    #warning
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Invariant:   should-be-true-if-populated-invariant
-Description: "Should be `true` if populated"
-Expression:  "$this.exists().not() or $this = true"
-Severity:    #warning
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
 Invariant:   shall-be-true-if-populated-invariant
 Description: "Shall be `true` if populated"
 Expression:  "$this.exists().not() or $this = true"

--- a/input/fsh/profiles_vaccination.fsh
+++ b/input/fsh/profiles_vaccination.fsh
@@ -43,7 +43,19 @@ Description: "Defines a profile representing a vaccination for a vaccine credent
 * reaction.detail only Reference(VaccineCredentialVaccineReactionObservation)
 
 * isSubpotent MS
-* isSubpotent ^definition = "Indication if a dose is considered to be subpotent. By default, a dose should be considered to be potent. Verifiers SHALL assume that if an Immunization resource is provided and isSubpotent is not true, then the dose was not subpotent. Issuers SHALL only populate isSubpotent if the value is true. Issuers SHALL NOT produce an Immunization resource for a known subpotent dose without populating isSubpotent."
+* isSubpotent ^definition = "Indication if a dose is considered to be subpotent.
+
+Issuers SHALL populate `isSubpotent` with `true` if the dose is known to be subpotent. Alternatively, Issuers MAY choose to not produce an Immunization resource at all if the dose is known to be subpotent as this resource would be unlikely to provide value to the other actors.
+
+Issuers SHALL NOT populate `isSubpotent` for potent doses.
+
+Verifiers SHALL assume that if an Immunization resource is provided and `isSubpotent` is not `true`, then the dose was fully potent."
+* isSubpotent ^comment = "It is critical that Verifiers process this element if it exists and is set to `true`. Therefore, `isSubpotent` is marked as `MustSupport` because it is also flagged with `Is-Modifier`, and per the [conformance requirements](conformance.html), Verifiers SHALL \"meaningfully process\" elements that are `MustSupport` and `Is-Modifier`.
+
+This element is therefore an exception to the guidance that Issuers must populate `MustSupport` elements if the data are available. An invariant is used to provide a computable representation of this exception: it will produce an error if `isSubpotent = false`, which is the expected value of this element for the vast majority of resources. Because full potency is implicit per this element's definition, we do not want to populate `isSubpotent` with `false` because it increases payload size without adding information.
+
+If `isSubpotent` was not allowed at all (`0..0` cardinality), the concern is that resources where `isSubpotent = true` would inadvertently be generated without any indication they were not potent."
+* isSubpotent obeys shall-be-true-if-populated-invariant
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -83,6 +95,8 @@ Description: "Defines a profile representing a vaccination for a vaccine credent
 // Required in DM profile to provide implementers with sterner warning when straying from the expected value sets
 * vaccineCode from VaccineCredentialVaccineValueSet (required)
 
+// Brought over from parent profile
+* isSubpotent obeys shall-be-true-if-populated-invariant
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Goal here is to explain why `isSubpotent` is MS and add an invariant to make the prose conformance criteria more computable.

Fixes #71

[CI build showing the main changes](https://github.com/dvci/vaccine-credential-ig/pull/77)