### PR TITLE
Strip non-DM properties from examples; fix gender in DM

### DIFF
--- a/input/examples/Scenario1Bundle.json
+++ b/input/examples/Scenario1Bundle.json
@@ -17,14 +17,7 @@
             ]
           }
         ],
-        "gender": "male",
-        "birthDate": "1951-01-20",
-        "address": [
-          {
-            "postalCode": "12345",
-            "country": "US"
-          }
-        ]
+        "birthDate": "1951-01-20"
       }
     },
     {

--- a/input/examples/Scenario1Patient.json
+++ b/input/examples/Scenario1Patient.json
@@ -13,12 +13,5 @@
         ]
       }
     ],
-    "gender": "male",
-    "birthDate": "1951-01-20",
-    "address": [
-      {
-        "postalCode": "12345",
-        "country": "US"
-      }
-    ]
+    "birthDate": "1951-01-20"
   }

--- a/input/examples/Scenario2Bundle.json
+++ b/input/examples/Scenario2Bundle.json
@@ -17,14 +17,7 @@
             ]
           }
         ],
-        "gender": "male",
-        "birthDate": "1961-01-20",
-        "address": [
-          {
-            "postalCode": "12345",
-            "country": "US"
-          }
-        ]
+        "birthDate": "1961-01-20"
       }
     },
     {

--- a/input/examples/Scenario2Patient.json
+++ b/input/examples/Scenario2Patient.json
@@ -10,12 +10,5 @@
         ]
       }
     ],
-    "gender": "male",
-    "birthDate": "1961-01-20",
-    "address": [
-      {
-        "postalCode": "12345",
-        "country": "US"
-      }
-    ]
+    "birthDate": "1961-01-20"
   }

--- a/input/examples/Scenario3Bundle.json
+++ b/input/examples/Scenario3Bundle.json
@@ -17,29 +17,7 @@
             ]
           }
         ],
-        "telecom": [
-          {
-            "system": "phone",
-            "value": "555-555-5555",
-            "use": "home"
-          },
-          {
-            "system": "email",
-            "value": "john.anyperson@example.com"
-          }
-        ],
-        "gender": "male",
-        "birthDate": "1951-01-20",
-        "address": [
-          {
-            "line": [
-              "123 Main St"
-            ],
-            "city": "Anytown",
-            "postalCode": "12345",
-            "country": "US"
-          }
-        ]
+        "birthDate": "1951-01-20"
       }
     },
     {

--- a/input/fsh/profiles_admin.fsh
+++ b/input/fsh/profiles_admin.fsh
@@ -18,11 +18,6 @@ Description: "Slight modification of Patient, with identifier as 0..0 and limite
 * name ^definition = "Official name (i.e., legal name) of the patient, corresponding to `official` in [this value set](http://hl7.org/fhir/R4/valueset-name-use.html). Issuers SHALL provide a single `name` element UNLESS they believe providing multiple `name` elements is critical for verification of the credential. If providing only a single `name` element, Issuers SHALL NOT populate `name.use`, and Verifiers SHALL assume that the provided name is `official`."
 * name ^comment = "Cardinality for this element is set to `1..*` rather than `1..1` as in rare cases there may be a valid rational for including multiple `name` elements. The Data Minimization version of this profile reflects the rarity of this by setting `name` to `1..1`."
 
-// Gender may be important if data in this IG were being used to populate IIS. However this is not
-// currently a use case for the IG so it is not required or MS.
-// See https://github.com/dvci/vaccine-credential-ig/pull/31#issuecomment-773434836 for details
-* gender from http://hl7.org/fhir/ValueSet/administrative-gender (required)
-
 // We want address.country and address.postalCode to be included if available
 // See https://github.com/dvci/vaccine-credential-ig/issues/37#issuecomment-776042494
 * address MS
@@ -56,6 +51,7 @@ Description: "Only elements necessary for Verifiers can be populated."
 * name.extension 0..0
 * name.use 0..0
 * telecom 0..0
+* gender 0..0
 * deceased[x] 0..0
 * address.id 0..0
 * address.extension 0..0

--- a/input/fsh/profiles_admin.fsh
+++ b/input/fsh/profiles_admin.fsh
@@ -18,12 +18,6 @@ Description: "Slight modification of Patient, with identifier as 0..0 and limite
 * name ^definition = "Official name (i.e., legal name) of the patient, corresponding to `official` in [this value set](http://hl7.org/fhir/R4/valueset-name-use.html). Issuers SHALL provide a single `name` element UNLESS they believe providing multiple `name` elements is critical for verification of the credential. If providing only a single `name` element, Issuers SHALL NOT populate `name.use`, and Verifiers SHALL assume that the provided name is `official`."
 * name ^comment = "Cardinality for this element is set to `1..*` rather than `1..1` as in rare cases there may be a valid rational for including multiple `name` elements. The Data Minimization version of this profile reflects the rarity of this by setting `name` to `1..1`."
 
-// We want address.country and address.postalCode to be included if available
-// See https://github.com/dvci/vaccine-credential-ig/issues/37#issuecomment-776042494
-* address MS
-* address.country MS
-* address.postalCode MS
-
 * birthDate MS
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -53,16 +47,7 @@ Description: "Only elements necessary for Verifiers can be populated."
 * telecom 0..0
 * gender 0..0
 * deceased[x] 0..0
-* address.id 0..0
-* address.extension 0..0
-* address.use 0..0
-* address.type 0..0
-* address.text 0..0
-* address.line 0..0
-* address.city 0..0
-* address.state 0..0
-* address.period 0..0
-* address.text 0..0
+* address 0..0
 * maritalStatus 0..0
 * multipleBirth[x] 0..0
 * photo 0..0


### PR DESCRIPTION
* I *think* the "gender" definition on our Patient profile wasn't adding anything beyond the FHIR Core definition, so I removed that
* Since gender is not MS or required, I removed it from the Patient DM profile
* I removed example patient elements that aren't part of the DM data set; we may want some, but we should be intentional/judicious when creating examples that include beyond the DM set