### PR TITLE
Fix prose guidance to line up with profiles for meta.security

### DIFF
--- a/.github/workflows/notify-early-adopters.yml
+++ b/.github/workflows/notify-early-adopters.yml
@@ -17,4 +17,4 @@ jobs:
             --user ${{secrets.ZULIP_USER}} \
             --stream ${{secrets.ZULIP_STREAM}} \
             --subject "Early Adopters: Review Request" \
-            --message "@shc-ig-early-adopters: [${{github.event[github.event_name].number}} ${{github.event[github.event_name].title}}](${{github.event[github.event_name].html_url}}) is ready for review"
+            --message "@*shc-ig-early-adopters*: [${{github.event[github.event_name].number}} ${{github.event[github.event_name].title}}](${{github.event[github.event_name].html_url}}) is ready for review"

--- a/.github/workflows/notify-early-adopters.yml
+++ b/.github/workflows/notify-early-adopters.yml
@@ -17,4 +17,4 @@ jobs:
             --user ${{secrets.ZULIP_USER}} \
             --stream ${{secrets.ZULIP_STREAM}} \
             --subject "Early Adopters: Review Request" \
-            --message "@*shc-ig-early-adopters*: [${{github.event[github.event_name].number}} ${{github.event[github.event_name].title}}](${{github.event[github.event_name].html_url}}) is ready for review"
+            --message "@*shc-ig-early-adopters*: [#${{github.event[github.event_name].number}}: ${{github.event[github.event_name].title}}](${{github.event[github.event_name].html_url}}) is ready for review"

--- a/input/pagecontent/conformance.md
+++ b/input/pagecontent/conformance.md
@@ -39,7 +39,7 @@ See the following section for information on how to validate against the DM prof
 
 Additionally:
 
-- Implementers SHOULD NOT populate `Resource.id`, `Resource.meta`, or `Resource.text` elements.
+- Implementers SHOULD NOT populate `Resource.id` or `Resource.text` elements. `Resource.meta` SHOULD NOT be populated, except for `Resource.meta.security` in the vaccination and laboratory test results profiles.
 
 - Implementers SHALL use `resource:0` syntax for IDs and references.
     - Implementers SHALL populate `Bundle.entry.fullUrl` elements with short resource-scheme URIs (e.g., `{"fullUrl": "resource:0}`).


### PR DESCRIPTION
This fixes an inconsistency with the prose conformance guidance.

**The profiles already reflect this so this is just a minor correction to the documentation.** I'm including the `early-adopter-review` label just to test the Zulip notifications.