### PR TITLE
Remove `category` from lab results (breaking change)

### DIFF
--- a/examples/Scenario3Bundle.json
+++ b/examples/Scenario3Bundle.json
@@ -27,16 +27,6 @@
           "security": [{"code": "IAL1"}]
         },
         "status": "final",
-        "category": [
-          {
-            "coding": [
-              {
-                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                "code": "laboratory"
-              }
-            ]
-          }
-        ],
         "code": {
           "coding": [
             {

--- a/input/data/examples.json
+++ b/input/data/examples.json
@@ -20,13 +20,13 @@
     "StructureDefinition-covid19-laboratory-result-observation.html": [
         {
             "title": "COVID-19 test results example",
-            "url": "https://github.com/dvci/vaccine-credential-ig/blob/GIT_BRANCH_GOES_HERE/examples/Scenario3Bundle.json#L25-L64"
+            "url": "https://github.com/dvci/vaccine-credential-ig/blob/GIT_BRANCH_GOES_HERE/examples/Scenario3Bundle.json#L25-L54"
         }
     ],
     "StructureDefinition-infectious-disease-laboratory-result-observation.html": [
         {
             "title": "COVID-19 test results example",
-            "url": "https://github.com/dvci/vaccine-credential-ig/blob/GIT_BRANCH_GOES_HERE/examples/Scenario3Bundle.json#L25-L64"
+            "url": "https://github.com/dvci/vaccine-credential-ig/blob/GIT_BRANCH_GOES_HERE/examples/Scenario3Bundle.json#L25-L54"
         }
     ],
     "StructureDefinition-vaccination-credential-bundle.html": [
@@ -54,7 +54,7 @@
         "StructureDefinition-covid19-laboratory-result-observation.html": [
         {
             "title": "COVID-19 test results example",
-            "url": "https://github.com/dvci/vaccine-credential-ig/blob/GIT_BRANCH_GOES_HERE/examples/Scenario3Bundle.json#L25-L64"
+            "url": "https://github.com/dvci/vaccine-credential-ig/blob/GIT_BRANCH_GOES_HERE/examples/Scenario3Bundle.json#L25-L54"
         }
     ],
     "StructureDefinition-vaccination-credential-patient.html": [

--- a/input/fsh/profiles_lab.fsh
+++ b/input/fsh/profiles_lab.fsh
@@ -11,8 +11,6 @@ RuleSet: LaboratoryResultObservation
 
 * status MS
 
-* category 0..0
-
 * code MS
 
 * subject only Reference(VaccinationCredentialPatient)
@@ -116,6 +114,7 @@ RuleSet: LaboratoryResultObservationDM
 * modifierExtension 0..0
 * basedOn 0..0
 * partOf 0..0
+* category 0..0
 * encounter 0..0
 * focus 0..0
 * issued 0..0

--- a/input/fsh/profiles_lab.fsh
+++ b/input/fsh/profiles_lab.fsh
@@ -11,15 +11,7 @@ RuleSet: LaboratoryResultObservation
 
 * status MS
 
-* category MS
-* category 1..1
-* category ^slicing.discriminator.type = #pattern
-* category ^slicing.discriminator.path = "$this"
-* category ^slicing.rules = #open
-* category ^slicing.description = "Slice based on the $this pattern"
-* category contains
-    laboratory 1..1 MS
-* category[laboratory] = ObsCat#laboratory
+* category 0..0
 
 * code MS
 
@@ -42,12 +34,6 @@ RuleSet: LaboratoryResultObservation
 * performer 0..1
 * performer ^short = "Organization which was responsible for laboratory record."
 * performer ^definition = "Organization which was responsible for laboratory record. Issuers SHOULD provide display name only. This is provided to Verifiers in case of invalid data in the credential, to support manual validation. This is not expected to be a computable Organization identifier."
-
-// VCI-specific (not from US Core)
-* insert id-should-not-be-populated()
-* category[laboratory].coding MS
-* category[laboratory].coding.code MS
-* category[laboratory].coding.system MS
 
 * meta.security 0..1
 * meta.security from IdentityAssuranceLevelValueSet (required)
@@ -130,14 +116,6 @@ RuleSet: LaboratoryResultObservationDM
 * modifierExtension 0..0
 * basedOn 0..0
 * partOf 0..0
-* category[laboratory].extension 0..0
-* category[laboratory].id 0..0
-* category[laboratory].text 0..0
-* category[laboratory].coding.id 0..0
-* category[laboratory].coding.version 0..0
-* category[laboratory].coding.display 0..0
-* category[laboratory].coding.userSelected 0..0
-* category[laboratory].coding.extension 0..0
 * encounter 0..0
 * focus 0..0
 * issued 0..0
@@ -158,8 +136,6 @@ RuleSet: LaboratoryResultObservationDM
 * performer.type 0..0
 * performer.identifier 0..0
 * valueCodeableConcept.text 0..0
-
-* category ^slicing.rules = #closed
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
We recently realized that `Observation.category` is not required in the base `Observation` resource, and can therefore be omitted. This will reduce the payload for lab results significantly as the following boilerplate will no longer need to appear in every Observation resource:

```
        "category": [
          {
            "coding": [
              {
                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
                "code": "laboratory"
              }
            ]
          }
        ],
```

We included `category` initially because [it is required in US Core](https://www.hl7.org/fhir/us/core/StructureDefinition-us-core-observation-lab.html), but when we moved away from inheriting from the US Core profiles we neglected to remove it. My apologies for missing this!

This PR will disallow category from both the AD and DM profiles as it does not appear to add value to any Actor in our use case, and takes up a lot of space in our limited payload.

@jmandel if this change is ok with implementers, I will submit a PR to update the SMART Health Card examples.