### PR TITLE
Add invariant to constrain Observation.status to codes with a canonical status of `complete`

### DIFF
--- a/input/fsh/invariants.fsh
+++ b/input/fsh/invariants.fsh
@@ -95,3 +95,10 @@ Expression:  "$this.lower().matches('lot').not()"
 Severity:    #warning
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+Invariant:   observation-status-shall-be-complete
+Description: "SHALL be `final`, `amended`, or `corrected`"
+Expression:  "$this.lower().matches('final') or $this.lower().matches('amended') or $this.lower().matches('corrected')"
+Severity:    #error
+
+////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/input/fsh/profiles_lab.fsh
+++ b/input/fsh/profiles_lab.fsh
@@ -49,6 +49,8 @@ RuleSet: LaboratoryResultObservation
 * category[laboratory].coding.code MS
 * category[laboratory].coding.system MS
 
+* status obeys observation-status-shall-be-complete
+
 * meta.security 0..1
 * meta.security from IdentityAssuranceLevelValueSet (required)
 * meta.security ^short = "Limited security label to convey identity level of assurance for patient referenced by this resource. Coding SHOULD include only code."


### PR DESCRIPTION
This is technically a breaking change, but I don't expect it to affect any implementations as `status` is already `1..1` and has a required value set binding, and presumably Issuers aren't issuing credentials for observations that aren't complete.

This will be merged in by the end of the week barring objections from implementers.