### PR TITLE
Terminology improvements

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -3,3 +3,13 @@ Alias: LNC = http://loinc.org
 Alias: SCT = http://snomed.info/sct
 Alias: ACT = http://terminology.hl7.org/CodeSystem/v3-ActReason
 Alias: LOA = http://terminology.hl7.org/CodeSystem/loa
+
+// LOINCs for COVID lab tests
+// https://www.nlm.nih.gov/vsac/support/usingvsac/covid19valuesets.html
+// https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1114.9/expansion
+Alias: covid-lab-tests-loinc-vsac = http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1114.9
+
+// SNOMED codes for COVID lab test results
+// https://www.nlm.nih.gov/vsac/support/usingvsac/covid19valuesets.html
+// https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1114.10/expansion
+Alias: covid-lab-test-results-snomed-vsac = http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1114.10

--- a/input/fsh/invariants.fsh
+++ b/input/fsh/invariants.fsh
@@ -12,31 +12,10 @@ Severity: #error
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Invariant:   vaccine-code-invariant
-Description: "CVX code should be provided if an applicable CVX code exists."
-Expression:  "coding.where($this.memberOf('http://hl7.org/fhir/uv/smarthealthcards-vaccination/ValueSet/vaccination-credential-cvx-value-set').not()).exists()"
-Severity:    #warning
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-Invariant:   covid19-laboratory-test-code-invariant
-Description: "Code from value set should be provided if an applicable code exists."
-Expression:  "coding.where($this.memberOf('http://hl7.org/fhir/uv/smarthealthcards-vaccination/ValueSet/covid19-laboratory-test-value-set').not()).exists()"
-Severity:    #warning
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-Invariant:   not-specified-laboratory-test-code-invariant
-Description: "Code cannot be part of a value set for a specified disease. Instead, validate against the profile specific for the disease in question."
-Expression:  "$this.memberOf('http://hl7.org/fhir/uv/smarthealthcards-vaccination/ValueSet/covid19-laboratory-test-value-set').not()"
+Invariant:   shall-not-be-a-covid-loinc
+Description: "This profile SHALL NOT be used to report results from COVID lab tests (https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1114.9/expansion). Use Covid19LaboratoryResultObservation instead."
+Expression:  "$this.memberOf('http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1114.9').not()"
 Severity:    #error
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-Invariant:   laboratory-result-invariant
-Description: "Code from value set should be provided if an applicable code exists."
-Expression:  "coding.where($this.memberOf('http://hl7.org/fhir/uv/smarthealthcards-vaccination/ValueSet/laboratory-result-value-set').not()).exists()"
-Severity:    #warning
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/input/fsh/profiles_admin.fsh
+++ b/input/fsh/profiles_admin.fsh
@@ -19,7 +19,7 @@ Description: "Slight modification of Patient, with identifier as 0..0 and limite
 * name and name.given and name.family MS
 * name obeys name-invariant
 * name ^short = "Official name (i.e., legal name) of patient"
-* name ^definition = "Official name (i.e., legal name) of the patient, corresponding to `official` in [this value set](http://hl7.org/fhir/R4/valueset-name-use.). Issuers SHALL provide a single `name` element UNLESS they believe providing multiple `name` elements is critical for verification of the credential. If providing only a single `name` element, Issuers SHALL NOT populate `name.use`, and Verifiers SHALL assume that the provided name is `official`."
+* name ^definition = "Official name (i.e., legal name) of the patient, corresponding to `official` in [this value set](https://www.hl7.org/fhir/valueset-name-use.html). Issuers SHALL provide a single `name` element UNLESS they believe providing multiple `name` elements is critical for verification of the credential. If providing only a single `name` element, Issuers SHALL NOT populate `name.use`, and Verifiers SHALL assume that the provided name is `official`."
 * name ^comment = "Cardinality for this element is set to `1..*` rather than `1..1` as in rare cases there may be a valid rational for including multiple `name` elements. The Data Minimization version of this profile reflects the rarity of this by setting `name` to `1..1`."
 
 * birthDate MS

--- a/input/fsh/profiles_lab.fsh
+++ b/input/fsh/profiles_lab.fsh
@@ -72,14 +72,13 @@ previous infection status."
 * insert LaboratoryResultObservation
 
 // This binding can be required because implementers can fall back to InfectiousDiseaseLaboratoryResultObservation
-* code from Covid19LaboratoryTestValueSet (required)
-* code obeys covid19-laboratory-test-code-invariant
-* code ^definition = "If the Covid19LaboratoryTestValueSet does not contain a code for the lab test, use the InfectiousDiseaseLaboratoryResultObservation profile."
+* code from covid-lab-tests-loinc-vsac (required)
+* code ^definition = "If an appropriate code is not found in the bound value set, use the InfectiousDiseaseLaboratoryResultObservation profile instead, which does not have a required binding."
 
 * value[x] 1..1
 * value[x] only CodeableConcept or Quantity
-* valueCodeableConcept from LaboratoryResultValueSet (extensible)
-* valueCodeableConcept obeys laboratory-result-invariant
+* valueCodeableConcept from covid-lab-test-results-snomed-vsac (required)
+* code ^definition = "If an appropriate code is not found in the bound value set, use the InfectiousDiseaseLaboratoryResultObservation profile instead, which does not have a required binding."
 * valueCodeableConcept.text obeys should-be-omitted
 
 /*
@@ -155,10 +154,6 @@ previous infection status. Only elements necessary for Verifiers can be populate
 
 * insert LaboratoryResultObservationDM
 
-// Required in DM profile to provide implementers with sterner warning when straying from the expected value sets
-* code from Covid19LaboratoryTestValueSet (required)
-
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 Profile:        InfectiousDiseaseLaboratoryResultObservation
@@ -172,12 +167,12 @@ Description:    "Profile for reporting laboratory results indicating current or 
 // Show an error if the code is part of a value set used in a disease-specific profile. If that's
 // the case, there's no reason to use this generic profile -- the disease-specific profile should
 // be used instead.
-* code obeys not-specified-laboratory-test-code-invariant
+* code from VaccinationCredentialLabTestValueSet (required)
+* code obeys shall-not-be-a-covid-loinc
 
 * value[x] 1..1
 * value[x] only CodeableConcept or Quantity
-* valueCodeableConcept from LaboratoryResultValueSet (extensible)
-* valueCodeableConcept obeys laboratory-result-invariant
+* valueCodeableConcept from VaccinationCredentialLabTestResultsValueSet (required)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/input/fsh/profiles_vaccination.fsh
+++ b/input/fsh/profiles_vaccination.fsh
@@ -31,14 +31,31 @@ Description: "Defines a profile representing a vaccination for a vaccination cre
 // Parent profile short description is not as clear as it could be
 * primarySource ^short = "Information in this record from person who administered vaccine?"
 
+
+
+// Vaccine code
+* vaccineCode 1..1
 * vaccineCode MS
-* vaccineCode from VaccinationCredentialVaccineValueSet (extensible)
-* vaccineCode obeys vaccine-code-invariant
-* vaccineCode ^definition = "Implementers SHALL use a code from VaccinationCredentialVaccineValueSet if this value set contains an appropriate code.
+* vaccineCode from VaccinationCredentialVaccineValueSet (required)
+* vaccineCode ^short = "Codes identifying the vaccine product administered"
 
-For COVID-19-related vaccinations, implementers SHOULD use one of the CVX codes [listed on the CDC's COVID-19 vaccine-related codes list](https://www.cdc.gov/vaccines/programs/iis/COVID-19-related-codes.html) whenever possible.
+* vaccineCode.coding ^slicing.discriminator.type = #value
+* vaccineCode.coding ^slicing.discriminator.path = "system"
+* vaccineCode.coding ^slicing.rules = #closed
+* vaccineCode.coding ^slicing.description = "Slicing based on the code system"
 
-We are actively investigating adding additional codes that are not United States-centric."
+* vaccineCode.coding contains
+    vaccine 1..1 MS and
+    vaccineManufacturer 0..1 MS
+
+* vaccineCode.coding[vaccine] ^short = "Vaccine administered"
+* vaccineCode.coding[vaccine] from VaccinationCredentialVaccineValueSet (required)
+
+* vaccineCode.coding[vaccineManufacturer] ^short = "Manufacturer of the administered vaccine"
+* vaccineCode.coding[vaccineManufacturer] from VaccinationCredentialVaccineManufacturerValueSet (required)
+
+
+
 
 * lotNumber MS
 * lotNumber obeys should-be-under-20-chars
@@ -70,10 +87,17 @@ We are actively investigating adding additional codes that are not United States
 // This is the value set we would use if we were including `statusReason`
 // * statusReason from VaccinationCredentialStatusReasonValueSet (extensible)
 
-* reportOrigin from VaccinationCredentialReportOriginValueSet (extensible)
-* site from VaccinationCredentialVaccineSiteValueSet (extensible)
-* route from VaccinationCredentialVaccineRouteValueSet (extensible)
-* fundingSource from VaccinationCredentialFundingSourceValueSet (extensible)
+// Support for IIS value set for RXA-9 - this is part of CDC NIP001
+// * reportOrigin from http://phinvads.cdc.gov/fhir/ValueSet/2.16.840.1.114222.4.11.7450 (extensible)
+
+// Support for IIS value set for RXR-2
+// * site from http://terminology.hl7.org/ValueSet/v2-0163 (extensible)
+
+// Support for IIS value set for RXR-1
+// * route from https://terminology.hl7.org/2.1.0/ValueSet-v2-0162.html (extensible)
+
+// Support for IIS value set for OBX-5 (extensible)
+// * fundingSource from http://phinvads.cdc.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3287 (extensible)
 
 * reaction.detail only Reference(VaccinationCredentialVaccineReactionObservation)
 
@@ -178,7 +202,7 @@ profile, VaccinationCredentialVaccineReactionValueSet includes the IIS adverse r
 
 * value[x] only CodeableConcept
 * valueCodeableConcept 1..1 MS
-* valueCodeableConcept from VaccinationCredentialVaccineReactionValueSet (extensible)
+* valueCodeableConcept from http://phinvads.cdc.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3288 (extensible)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/input/fsh/value_sets.fsh
+++ b/input/fsh/value_sets.fsh
@@ -2,129 +2,40 @@
 
 ValueSet:    VaccinationCredentialVaccineValueSet
 Id:          vaccination-credential-vaccine-value-set
-Title:       "Value set for identifying vaccines"
-Description: "This value set includes codes for identifying vaccinations."
+Title:       "Vaccines value set"
+Description: "This value set includes codes for identifying vaccines."
 
+// CVX codes - identifies disease and type of vaccine
 * include codes from system http://hl7.org/fhir/sid/cvx
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+ValueSet:    VaccinationCredentialVaccineManufacturerValueSet
+Id:          vaccination-credential-vaccine-manufacturer-value-set
+Title:       "Vaccine manufacturer value set"
+Description: "This value set includes codes for identifying vaccine manufacturers."
 
-// For Immunization.statusReason -- this element is currently not allowed
-/*
-ValueSet:    VaccinationCredentialStatusReasonValueSet
-Id:          vaccination-credential-status-reason-value-set
-Title:       "Status reason value set"
-Description: "Reasons a vaccine was not given"
-* ACT#IMMUNE
-* ACT#MEDPREC
-* ACT#OSTOCK
-* ACT#PATOBJ
-
-// Support for IIS value set for RXA-18 (refusal reason) - this is CDC NIP002
-* include codes from system http://phinvads.cdc.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3380
-*/
+// MVX codes - identifies manufacturer https://phinvads.cdc.gov/vads/ViewValueSet.action?oid=2.16.840.1.114222.4.11.826
+* include codes from valueset http://phinvads.cdc.gov/fhir/ValueSet/2.16.840.1.114222.4.11.826
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// For Immunization.reportOrigin
-ValueSet:    VaccinationCredentialReportOriginValueSet
-Id:          vaccination-credential-report-origin-value-set
-Title:       "Secondarily reported record source value set"
-Description: "Source of secondarily reported records"
+ValueSet:    VaccinationCredentialLabTestValueSet
+Id:          vaccination-credential-lab-test-value-set
+Title:       "Laboratory tests value set"
+Description: "This value set includes codes for identifying laboratory tests."
 
-// Support for example binding from base FHIR Immunization resource
-* include codes from system http://hl7.org/fhir/ValueSet/immunization-origin
-
-// Support for IIS value set for RXA-9 - this is part of CDC NIP001
-* include codes from system http://phinvads.cdc.gov/fhir/ValueSet/2.16.840.1.114222.4.11.7450
+* include codes from system LNC
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// For Immunization.site
-ValueSet:    VaccinationCredentialVaccineSiteValueSet
-Id:          vaccination-credential-vaccine-site-value-set
-Title:       "Body site for vaccine administration value set"
-Description: "Body site vaccine was administered"
+ValueSet:    VaccinationCredentialLabTestResultsValueSet
+Id:          vaccination-credential-lab-test-results-value-set
+Title:       "Laboratory test results value set"
+Description: "This value set includes codes for identifying laboratory test results."
 
-// Support for IIS value set for RXR-2
-* include codes from system http://terminology.hl7.org/CodeSystem/v2-0163
-
-// Support for example binding from base FHIR Immunization resource
-* include codes from system http://terminology.hl7.org/CodeSystem/v3-ActSite
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// For Immunization.route
-ValueSet:    VaccinationCredentialVaccineRouteValueSet
-Id:          vaccination-credential-vaccine-route-value-set
-Title:       "Vaccination route value set"
-Description: "How vaccine entered the body"
-
-// Support for IIS value set for RXR-1
-* include codes from system http://terminology.hl7.org/CodeSystem/v2-0162
-
-// Support for example binding from base FHIR Immunization resource
-* include codes from valueset http://hl7.org/fhir/ValueSet/immunization-route
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// Not sure if we want to create a value set for program eligibility. This is presumably not
-// relevant for COVID-19, and the IIS value set (for OBX-5) is user-defined.
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// For Immunization.fundingSource
-ValueSet:    VaccinationCredentialFundingSourceValueSet
-Id:          vaccination-credential-funding-source-value-set
-Title:       "Funding source value set"
-Description: "Funding source for the vaccine"
-
-// Support for IIS value set for OBX-5 (extensible)
-* include codes from system http://phinvads.cdc.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3287
-
-// Support for example binding from base FHIR Immunization resource
-* include codes from system http://hl7.org/fhir/ValueSet/immunization-funding-source
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// For vaccine reaction Observation (VaccinationCredentialVaccineReactionObservation)
-ValueSet:    VaccinationCredentialVaccineReactionValueSet
-Id:          vaccination-credential-vaccine-reaction-value-set
-Title:       "Adverse reaction value set"
-Description: "Codes describing reactions to vaccinations"
-
-// Support for IIS value set for OBX-5
-// Source: https://phinvads.cdc.gov/vads/ViewValueSet.action?oid=2.16.840.1.114222.4.11.3288
-* include codes from system http://phinvads.cdc.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3288
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-ValueSet:    Covid19LaboratoryTestValueSet
-Id:          covid19-laboratory-test-value-set
-Title:       "COVID-19 laboratory test code value set"
-Description: "Currently includes COVID-19 lab codes via the
-[LIVD SARS CoV2 Test Codes value set](https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1114.9/expansion)."
-
-// Support for CDC LIVD SARS CoV2 Test Codes
-* include codes from system http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1114.9
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-ValueSet:    LaboratoryResultValueSet
-Id:          laboratory-result-value-set
-Title:       "Laboratory result value set"
-Description: "Currently includes COVID-19 lab result codes based on the conclusive values from the
-[LIVD SARS CoV2 Test Result Codes value set](https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1114.10/expansion).
-Other value sets may be added in the future."
-
-* SCT#10828004 "Positive (qualifier value)"
-* SCT#260373001 "Detected (qualifier value)"
-* SCT#260385009 "Negative (qualifier value)"
-* SCT#260408008 "Weakly positive (qualifier value)"
-* SCT#260415000 "Not detected (qualifier value)"
-* SCT#720735008 "Presumptive positive (qualifier value)"
+// Include all clinical finding codes
+* include codes from system SCT where concept is-a #404684003
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/input/includes/markdown-link-references.md
+++ b/input/includes/markdown-link-references.md
@@ -19,15 +19,10 @@
 [VaccinationCredentialVaccineReactionObservationDM]: StructureDefinition-vaccination-credential-vaccine-reaction-observation-dm.html
 [VaccinationCredentialVaccineReactionObservation]: StructureDefinition-vaccination-credential-vaccine-reaction-observation.html
 
-[Covid19LaboratoryTestValueSet]: ValueSet-covid19-laboratory-test-value-set.html
 [IdentityAssuranceLevelValueSet]: ValueSet-identity-assurance-level-value-set.html
-[LaboratoryResultValueSet]: ValueSet-laboratory-result-value-set.html
-[VaccinationCredentialFundingSourceValueSet]: ValueSet-vaccination-credential-funding-source-value-set.html
-[VaccinationCredentialReportOriginValueSet]: ValueSet-vaccination-credential-report-origin-value-set.html
-[VaccinationCredentialStatusReasonValueSet]: ValueSet-vaccination-credential-status-reason-value-set.html
-[VaccinationCredentialVaccineReactionValueSet]: ValueSet-vaccination-credential-vaccine-reaction-value-set.html
-[VaccinationCredentialVaccineRouteValueSet]: ValueSet-vaccination-credential-vaccine-route-value-set.html
-[VaccinationCredentialVaccineSiteValueSet]: ValueSet-vaccination-credential-vaccine-site-value-set.html
+[VaccinationCredentialLabTestResultsValueSet]: ValueSet-vaccination-credential-lab-test-results-value-set.html
+[VaccinationCredentialLabTestValueSet]: ValueSet-vaccination-credential-lab-test-value-set.html
+[VaccinationCredentialVaccineManufacturerValueSet]: ValueSet-vaccination-credential-vaccine-manufacturer-value-set.html
 [VaccinationCredentialVaccineValueSet]: ValueSet-vaccination-credential-vaccine-value-set.html
 
 [Scenario1Bundle]: https://github.com/dvci/vaccine-credential-ig/blob/{{ site.data['git-branch'] }}/examples/Scenario1Bundle.json

--- a/input/includes/menu.xml
+++ b/input/includes/menu.xml
@@ -46,7 +46,7 @@
     <a data-toggle="dropdown" href="#" class="dropdown-toggle">Value Sets<b class="caret"></b></a>
     <ul class="dropdown-menu">
       <li><a href="ValueSet-vaccination-credential-vaccine-value-set.html">Vaccines</a></li>
-      <li><a href="ValueSet-vaccination-credential-vaccine-value-set.html">Vaccine manufacturers</a></li>
+      <li><a href="ValueSet-vaccination-credential-vaccine-manufacturer-value-set.html">Vaccine manufacturers</a></li>
 
       <li role="separator" class="divider"></li>
 

--- a/input/includes/menu.xml
+++ b/input/includes/menu.xml
@@ -45,21 +45,17 @@
   <li class="dropdown">
     <a data-toggle="dropdown" href="#" class="dropdown-toggle">Value Sets<b class="caret"></b></a>
     <ul class="dropdown-menu">
-      <li><a href="ValueSet-vaccination-credential-vaccine-value-set.html">Vaccines (CVX)</a></li>
-      <li><a href="ValueSet-vaccination-credential-vaccine-site-value-set.html">Vaccination Body Site</a></li>
-      <li><a href="ValueSet-vaccination-credential-funding-source-value-set.html">Vaccination Funding Source</a></li>
-      <li><a href="ValueSet-vaccination-credential-vaccine-reaction-value-set.html">Vaccination Reaction</a></li>
-      <li><a href="ValueSet-vaccination-credential-report-origin-value-set.html">Vaccination Report Origin</a></li>
-      <li><a href="ValueSet-vaccination-credential-vaccine-route-value-set.html">Vaccination Route</a></li>
+      <li><a href="ValueSet-vaccination-credential-vaccine-value-set.html">Vaccines</a></li>
+      <li><a href="ValueSet-vaccination-credential-vaccine-value-set.html">Vaccine manufacturers</a></li>
 
       <li role="separator" class="divider"></li>
 
-      <li><a href="ValueSet-laboratory-result-value-set.html">Lab Results</a></li>
-      <li><a href="ValueSet-covid19-laboratory-test-value-set.html">Lab Tests (COVID-19 only)</a></li>
+      <li><a href="ValueSet-vaccination-credential-lab-test-value-set.html">Lab tests</a></li>
+      <li><a href="ValueSet-vaccination-credential-lab-test-results-value-set.html">Lab test results</a></li>
 
       <li role="separator" class="divider"></li>
 
-      <li><a href="ValueSet-identity-assurance-level-value-set.html">Identity Assurance</a></li>
+      <li><a href="ValueSet-identity-assurance-level-value-set.html">Identity assurance levels</a></li>
     </ul>
   </li>
   <!--<li><a href="data-dictionary/data_dictionary.xlsx">Data Dictionary (.xlsx)</a></li>-->

--- a/input/pagecontent/StructureDefinition-covid19-laboratory-result-observation-intro.md
+++ b/input/pagecontent/StructureDefinition-covid19-laboratory-result-observation-intro.md
@@ -2,7 +2,7 @@
 
 #### Identifying laboratory tests
 
-Implementers SHALL use the [Covid19LaboratoryTestValueSet] to identify laboratory tests if a suitable code is available in that value set, which is reflected in the required binding for this value set.
+Implementers SHALL use [a COVID-19-specific LOINC](https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1114.9/expansion) to identify a COVID-19-related laboratory tests if a suitable code is available in that value set, which is reflected in the required binding for this value set.
 
 Implementers should fall back to [InfectiousDiseaseLaboratoryResultObservation] if a suitable code is not available; this fallback profile is the same as this one apart from the value set binding.
 

--- a/input/pagecontent/StructureDefinition-vaccination-credential-immunization-intro.md
+++ b/input/pagecontent/StructureDefinition-vaccination-credential-immunization-intro.md
@@ -2,7 +2,14 @@
 
 #### Identifying vaccines
 
-Implementers SHALL use the [VaccinationCredentialVaccineValueSet] to identify vaccinations if a suitable code is available in that value set. An extensible binding is used in this profile to provide flexibility ONLY if real-world circumstances require the use of a code outside this value set. The [data minimization version of this profile][VaccinationCredentialImmunizationDM] uses a required binding to reflect these conformance criteria.
+The `vaccineCode` element has two different slices, which are used to identify vaccines:
+
+1. `vaccineCode.coding[vaccine]` identifies the disease(s) targeted (e.g., COVID-19) and type of vaccine (e.g., mRNA) at a minimum. Valid codes are defined in [VaccinationCredentialVaccineValueSet], and currently include only [CVX codes](https://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=cvx) but will be expanded in the future to include similar codes from other code systems. For example, `CVX#208` is `COVID-19, mRNA, LNP-S, PF, 30 mcg/0.3 mL dose` and `CVX#197` is `influenza, high-dose, quadrivalent`. This slice is required.
+1. `vaccineCode.coding[vaccineManufacturer]` identifies the manufacturer of the vaccine. Valid codes are defined in [VaccinationCredentialVaccineManufacturerValueSet]. This slice is not required, but SHOULD be populated if the necessary data are available to the Issuer.
+
+Additional slices may be defined in the future if necessary to identify specific boosters for COVID-19 vaccinations.
+
+When vaccine and manufacturer are provided using US-centric terminology (CVX and MVX, respectively) for COVID-19 vaccinations, CDC [provides a list](https://www.cdc.gov/vaccines/programs/iis/COVID-19-related-codes.html) that includes "Sale Proprietary Name" (e.g., `Moderna COVID-19 Vaccine`). The "Sale Proprietary Name" or other trade name SHALL NOT be included in FHIR resources, but MAY be used by Issuers when producing human-readable representations of these resources.
 
 #### Conformance for `status` and `statusReason`
 

--- a/input/pagecontent/ValueSet-vaccination-credential-vaccine-manufacturer-value-set-intro.md
+++ b/input/pagecontent/ValueSet-vaccination-credential-vaccine-manufacturer-value-set-intro.md
@@ -1,0 +1,3 @@
+#### MVX Codes
+
+The CDC provides the [canonical list of valid MVX codes](hhttps://www2.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=mvx). **The expansion provided below may be out of date.** In cases where the expansion below differs from the CDC list linked above, implementers should defer to the CDC list.

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -3,8 +3,8 @@
 <div class="alert alert-info" role="alert" markdown="1">
 <p style="font-size: 2rem;"><strong>Known issues</strong></p>
 
-* The [HL7 representation of the CVX code system](https://terminology.hl7.org/1.0.0/CodeSystem-CVX.html) does is out of date with the [canonical list of CVX codes](https://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=cvx). We are working with HL7 to resolve this. In the meantime, you may see spurious validation errors related to invalid CVX codes.<br><br>
-* Other value sets in this IG are not being properly expanded. We are working to resolve this.<br><br>
+* The expansion of [VaccinationCredentialVaccineValueSet] currently has an out-of-date list of [CVX codes](https://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=cvx). This will be fixed in the next deploy of the HL7 terminology server (`tx.fhir.org`).<br><br>
+* Other value sets in this IG may also have out-of-date expansions. If a given code is listed in the canonical source for a given code system or value set, it should be considered valid regardless of the expansion in this IG.<br><br>
 * Validation with the FHIR Validator tool currently produces spurious errors for valid resources. [Details here](conformance.html#validation).
 
 </div>

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -88,7 +88,17 @@ The IG is currently focused on coordinating implementers' representations of rel
 
 1. More constrained profiles for risk evaluation can be created based on the profiles in this IG, but it's not possible to remove constraints in a child profile.
 
-1. Constraints are applied to specific data elements in [Allowable Data profiles](conformance.html#data-minimization) when their inclusion (1) is does not support our use case and could harm patients; or (2) is contrary to our [key design principles](https://vci.org/about#key-principles). For example, `Patient.identifier` is not allowed in resources conforming to [VaccinationCredentialPatient] as this may include a MRN or SSN, which would introduce a significant privacy risk for patients.
+1. Cardinality constraints are applied to specific data elements in [Allowable Data profiles](conformance.html#data-minimization) when their inclusion (1) is does not support our use case and could harm patients; or (2) is contrary to our [key design principles](https://vci.org/about#key-principles). For example, `Patient.identifier` is not allowed in resources conforming to [VaccinationCredentialPatient] as this may include a MRN or SSN, which would introduce a significant privacy risk for patients.
+
+### Approach to terminology bindings
+
+Value set bindings for [`MustSupport` elements](conformance.html) are `required`, meaning that resources MUST use a code specified in the bound value set. This is to ensure implementers know which code systems can be expected to appear in a given element.
+
+In general, the value sets used in these `required` bindings are as broad as possible. For example, in [VaccinationCredentialVaccineValueSet], all codes from the [CVX code system](https://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=cvx) are included (as opposed to defining a value set with just COVID-related CVX codes, for example).
+
+In cases where disease-specific value sets exist, this IG may provide profiles with bindings to these restricted value sets (e.g., [Covid19LaboratoryResultObservation]) to help implementers identify the preferred subset of codes for that disease. However, in these cases, this IG will also provide generic equivalents to these profiles with broad value sets (e.g., [InfectiousDiseaseLaboratoryResultObservation]). Implementers MAY fall back to the generic version such profiles if the code they need is not part of the disease-specific value sets.
+
+Currently this IG uses US-centric terminology. We plan to add support for non-US terminology, and welcome any implementers outside the US to [identify which code systems and value sets are needed for their use cases](https://github.com/dvci/vaccine-credential-ig/issues/83).
 
 ### Identity assurance
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -13,13 +13,13 @@ publisher:
   email: example@example.com
 version: 0.4.0-rc
 fhirVersion: 4.0.1
-# dependencies:
-#   us.cdc.phinvads:
-#     uri: http://fhir.org/packages/us.cdc.phinvads
-#     version: 0.7.0
-#   us.nlm.vsac:
-#     uri: http://fhir.org/packages/us.nlm.vsac
-#     version: 0.4.0
+dependencies:
+  us.cdc.phinvads:
+    uri: http://fhir.org/packages/us.cdc.phinvads
+    version: 0.7.0
+  us.nlm.vsac:
+    uri: http://fhir.org/packages/us.nlm.vsac
+    version: 0.4.0
 copyrightYear: 2020+
 license: Apache-2.0
 releaseLabel: ci-build


### PR DESCRIPTION
This PR makes a number of improvements to the terminology support in the IG.

All value sets are now properly expanding except for CVX, which [Grahame fixed in source code](https://chat.fhir.org/#narrow/stream/284830-smart.2Fhealth-cards/topic/CVX.20code.20system/near/235593424) and will be available soon.

## Breaking changes

### Value sets now have required bindings

Value sets are now `required` for all non-experimental profiles (namely our vaccination and lab test result profiles). This is **technically** a breaking change, but the value sets are as broad as possible so this change should not impact implementers who were already using any code in the currently supported terminology (CVX, LOINC, SNOMED). 

The rational behind this change is that we want to avoid unexpected data getting into profiles for privacy reasons, and we want implementers to know what code systems to expect when designing human-readable views of the FHIR resources.

Specifically:

* `Immunization.vaccineCode` has a required binding to **all** CVX codes
* The COVID-specific lab results profile has required bindings to the COVID-specific LOINC value set identifying lab tests, and to the COVID-specific SNOMED value set for lab test results. If the necessary codes are not in these value sets, implementers can simply use the generic infectious disease lab results profile (see next bullet).
* The generic infections disease lab results profile now has required bindings, but these are extremely broad: any LOINC for `Observation.code` and any SNOMED clinical finding for `Observation.valueCodeableConcept`. If additional codes need to be added to these value sets, please let us know.

**If these changes are problematic for implementers, please let us know!** Again, we do not expect this to be a problem for any existing implementations, but if it is we want to address the problem before this gets merged in.

## Other changes

* Added a section to the IG home page explaining the approach to terminology binding.

* Added a slice on `Immunization.vaccineCode` to support identifying vaccine manufacturer. We have been very focused on COVID-19 vaccines, and CVX codes currently differentiate manufacturer because only one manufacturer makes each type of vaccine. However, technically CVX identifies the vaccine type, and a 2nd code system (MVX) identifies the manufacturer.

    The new `Immunization.vaccineCode.coding[vaccineManufacturer]` slice is `MS` but **not** required, so this will not break existing implementations.

    However, because manufacturer is typically included on the CDC paper COVID vaccine card, implementers SHOULD add support for this if possible. This slice may be required in the "version 2" release of this IG depending on implementer feedback.

* Added value sets to support "all LOINC" and "all SNOMED clinical findings".

* Removed unused/unnecessary invariants.

* Fixed code system and value set URIs throughout the IG. These should not be breaking changes since the URIs for the code systems used in the key elements were already correct (CVX, LOINC, SNOMED).

* Removed value sets for non-MS elements as these should not be populated, so the value sets are not providing any value.