### PR TITLE
add observation status test, invariant prefix

### DIFF
--- a/input/fsh/invariants.fsh
+++ b/input/fsh/invariants.fsh
@@ -1,83 +1,84 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-Invariant:  vc-lab-1
-Description: "Bundle SHOULD only include results with status final or status that is subsequent to final."
+Invariant:  vc-bundle-lab-status-complete
+Description: "Bundle SHALL only include results with status final or status that is subsequent to final."
+Expression:  "$this.resource.ofType(Observation).status.lower() in ('final'|'amended'|'corrected')"
 Severity:   #error
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Invariant: name-invariant
+Invariant: vc-name-invariant
 Description: "Require one of the key name elements to be filled. Allows for `text` for names that cannot be cleanly categorized into `family` or `given` (https://www.nature.com/articles/d41586-020-02761-z)."
 Expression: "family.exists() or given.exists() or text.exists()"
 Severity: #error
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Invariant:   shall-not-be-a-covid-loinc
+Invariant:   vc-shall-not-be-a-covid-loinc
 Description: "This profile SHALL NOT be used to report results from COVID lab tests (https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1114.9/expansion). Use Covid19LaboratoryResultObservation instead."
 Expression:  "$this.memberOf('http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1114.9').not()"
 Severity:    #error
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Invariant:   date-invariant
+Invariant:   vc-date-invariant
 Description: "All timestamps SHOULD be represented as Dates (YYYY-MM-DD only)."
 Expression:  "$this.toString().matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}$')"
 Severity:    #warning
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Invariant:   shall-be-true-if-populated-invariant
+Invariant:   vc-shall-be-true-if-populated-invariant
 Description: "Shall be `true` if populated"
 Expression:  "$this.exists().not() or $this = true"
 Severity:    #error
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Invariant:   should-be-under-50-chars
+Invariant:   vc-should-be-under-50-chars
 Description: "Length SHOULD be <50 for data minimization."
-Expression:  "$this.length() < 50')"
+Expression:  "$this.length() < 50"
 Severity:    #warning
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Invariant:   should-be-under-20-chars
+Invariant:   vc-should-be-under-20-chars
 Description: "Length SHOULD be <20 for data minimization."
 Expression:  "$this.length() < 20"
 Severity:    #warning
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Invariant:   should-be-omitted
+Invariant:   vc-should-be-omitted
 Description: "SHOULD be omitted for data minimization."
 Expression:  "$this.length() = 0"
 Severity:    #warning
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Invariant:   should-be-omitted-privacy
+Invariant:   vc-should-be-omitted-privacy
 Description: "SHOULD be omitted to protect privacy and for data minimization."
 Expression:  "$this.length() = 0"
 Severity:    #warning
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Invariant:   shall-be-resource-uri
+Invariant:   vc-shall-be-resource-uri
 Description: "IDs SHALL use resource:# format"
 Expression:  "$this.matches('^resource:[0-9]+$')"
 Severity:    #error
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Invariant:   should-not-include-string-lot
+Invariant:   vc-should-not-include-string-lot
 Description: "lotNumber SHOULD NOT include `Lot #`, `Lot Number`, etc."
 Expression:  "$this.lower().matches('lot').not()"
 Severity:    #warning
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-Invariant:   observation-status-shall-be-complete
+Invariant:   vc-observation-status-shall-be-complete
 Description: "SHALL be `final`, `amended`, or `corrected`"
-Expression:  "$this.lower().matches('final') or $this.lower().matches('amended') or $this.lower().matches('corrected')"
+Expression:  "$this.lower() in ('final'|'amended'|'corrected')"
 Severity:    #error
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/input/fsh/profiles_admin.fsh
+++ b/input/fsh/profiles_admin.fsh
@@ -17,7 +17,7 @@ Description: "Slight modification of Patient, with identifier as 0..0 and limite
 
 * name 1..*
 * name and name.given and name.family MS
-* name obeys name-invariant
+* name obeys vc-name-invariant
 * name ^short = "Official name (i.e., legal name) of patient"
 * name ^definition = "Official name (i.e., legal name) of the patient, corresponding to `official` in [this value set](https://www.hl7.org/fhir/valueset-name-use.html). Issuers SHALL provide a single `name` element UNLESS they believe providing multiple `name` elements is critical for verification of the credential. If providing only a single `name` element, Issuers SHALL NOT populate `name.use`, and Verifiers SHALL assume that the provided name is `official`."
 * name ^comment = "Cardinality for this element is set to `1..*` rather than `1..1` as in rare cases there may be a valid rational for including multiple `name` elements. The Data Minimization version of this profile reflects the rarity of this by setting `name` to `1..1`."
@@ -52,7 +52,7 @@ Because gender is a common field in administrative data, it is possible Issuers 
 * insert contact-information-should-not-be-populated(address.postalCode)
 
 RuleSet: contact-information-should-not-be-populated(path)
-* {path} obeys should-be-omitted-privacy
+* {path} obeys vc-should-be-omitted-privacy
 * {path} ^comment = "For patient privacy reasons, this element SHALL NOT be populated unless the Issuer believes the credential cannot be verified in its absence."
 
 

--- a/input/fsh/profiles_bundle.fsh
+++ b/input/fsh/profiles_bundle.fsh
@@ -7,14 +7,14 @@ RuleSet: fullurl(path)
 * {path}fullUrl ^short = "Locally unique identifier like resource:0"
 * {path}fullUrl ^definition = "Identifier for the contained resource that is locally unique within this Bundle. The identifier SHALL use `resource:#` format, where `#` is an integer incremented from 0 to _n_ within the Bundle."
 * {path}fullUrl ^comment = "n/a"
-* {path}fullUrl obeys shall-be-resource-uri
+* {path}fullUrl obeys vc-shall-be-resource-uri
 
 RuleSet: common-bundle-rules
 
 * id ^short = "Should be omitted"
 * id ^definition = "It is not necessary to provide an `id` for Bundles profiled in this IG. This element SHOULD be omitted for data minimization reasons."
 * id ^comment = "n/a"
-* id obeys should-be-omitted
+* id obeys vc-should-be-omitted
 
 * type  = #collection
 * type MS
@@ -106,7 +106,7 @@ Description: "The bundle of resources that represents the clinical content of a 
 * entry[laboratoryResultObservation] ^short = "Laboratory result"
 * entry[laboratoryResultObservation] ^definition = "Laboratory result"
 * entry[laboratoryResultObservation].resource only Covid19LaboratoryResultObservation
-* entry[laboratoryResultObservation] obeys vc-lab-1
+* entry[laboratoryResultObservation] obeys vc-bundle-lab-status-complete
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -130,7 +130,7 @@ Description: "The bundle of resources that represents the clinical content of a 
 * entry[laboratoryResultObservation] ^short = "Laboratory result"
 * entry[laboratoryResultObservation] ^definition = "Laboratory result"
 * entry[laboratoryResultObservation].resource only InfectiousDiseaseLaboratoryResultObservation
-* entry[laboratoryResultObservation] obeys vc-lab-1
+* entry[laboratoryResultObservation] obeys vc-bundle-lab-status-complete
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -154,7 +154,7 @@ Description: "The bundle of resources that represents the clinical content of a 
 * entry[laboratoryResultObservation] ^short = "Laboratory result"
 * entry[laboratoryResultObservation] ^definition = "Laboratory result"
 * entry[laboratoryResultObservation].resource only InfectiousDiseaseLaboratoryResultObservationDM
-* entry[laboratoryResultObservation] obeys vc-lab-1
+* entry[laboratoryResultObservation] obeys vc-bundle-lab-status-complete
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -178,6 +178,6 @@ Description: "The bundle of resources that represents the clinical content of a 
 * entry[laboratoryResultObservation] ^short = "Laboratory result"
 * entry[laboratoryResultObservation] ^definition = "Laboratory result"
 * entry[laboratoryResultObservation].resource only Covid19LaboratoryResultObservationDM
-* entry[laboratoryResultObservation] obeys vc-lab-1
+* entry[laboratoryResultObservation] obeys vc-bundle-lab-status-complete
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/input/fsh/profiles_lab.fsh
+++ b/input/fsh/profiles_lab.fsh
@@ -26,7 +26,7 @@ RuleSet: LaboratoryResultObservation
 * value[x] ^comment = "Issuers SHALL provide a computable representation of laboratory results if at all possible. If the Issuer is unable to accurately translate laboratory results into a computable form, it is unlikely a Verifier will be able to interpret the results. Issuers SHALL make every possible effort to resolve non-computable results prior to issuing credentials. In rare cases when this is not possible, Issuers MAY populate `valueCodeableConcept.text` with a free text result. Populating `valueCodeableConcept.text` will result in a warning when validating against the Allowable Data profile and an error with the Data Minimization profile."
 * valueCodeableConcept.text ^short = "String representation of results when a computable representation is not possible"
 * valueCodeableConcept.text ^comment = "See comment for `value[x]`."
-* valueCodeableConcept.text obeys should-be-under-20-chars
+* valueCodeableConcept.text obeys vc-should-be-under-20-chars
 
 * performer only Reference(Organization)
 * performer MS
@@ -37,7 +37,7 @@ RuleSet: LaboratoryResultObservation
 // VCI-specific (not from US Core)
 * insert id-should-not-be-populated()
 
-* status obeys observation-status-shall-be-complete
+* status obeys vc-observation-status-shall-be-complete
 
 * meta.security 0..1
 * meta.security from IdentityAssuranceLevelValueSet (required)
@@ -55,7 +55,7 @@ RuleSet: LaboratoryResultObservation
 * performer.display MS
 * performer.display 1..1
 * performer.display ^definition = "Organization which was responsible for the laboratory test result. Issuers SHOULD provide display name only. This is provided to Verifiers in case of invalid data in the credential, to support manual validation. This is not expected to be a computable Organization identifier."
-* performer.display obeys should-be-under-20-chars
+* performer.display obeys vc-should-be-under-20-chars
 
 
 * insert reference-to-absolute-uri(subject)
@@ -79,7 +79,7 @@ previous infection status."
 * value[x] only CodeableConcept or Quantity
 * valueCodeableConcept from covid-lab-test-results-snomed-vsac (required)
 * code ^definition = "If an appropriate code is not found in the bound value set, use the InfectiousDiseaseLaboratoryResultObservation profile instead, which does not have a required binding."
-* valueCodeableConcept.text obeys should-be-omitted
+* valueCodeableConcept.text obeys vc-should-be-omitted
 
 /*
 TODO: Test using `device` rather than `method`, like so:
@@ -168,7 +168,7 @@ Description:    "Profile for reporting laboratory results indicating current or 
 // the case, there's no reason to use this generic profile -- the disease-specific profile should
 // be used instead.
 * code from VaccinationCredentialLabTestValueSet (required)
-* code obeys shall-not-be-a-covid-loinc
+* code obeys vc-shall-not-be-a-covid-loinc
 
 * value[x] 1..1
 * value[x] only CodeableConcept or Quantity

--- a/input/fsh/profiles_vaccination.fsh
+++ b/input/fsh/profiles_vaccination.fsh
@@ -26,7 +26,7 @@ Description: "Defines a profile representing a vaccination for a vaccination cre
 * occurrenceDateTime 1..1 MS
 * occurrenceDateTime ^definition = "Date vaccine administered (`YYYY-MM-DD` format)."
 * occurrenceDateTime ^comment = "For data minimization reasons, only year, month, and date SHOULD be reported for this element. Exact time (hour, minute, second) are not relevant for our use cases."
-* occurrenceDateTime obeys date-invariant
+* occurrenceDateTime obeys vc-date-invariant
 
 // Parent profile short description is not as clear as it could be
 * primarySource ^short = "Information in this record from person who administered vaccine?"
@@ -58,8 +58,8 @@ Description: "Defines a profile representing a vaccination for a vaccination cre
 
 
 * lotNumber MS
-* lotNumber obeys should-be-under-20-chars
-* lotNumber obeys should-not-include-string-lot
+* lotNumber obeys vc-should-be-under-20-chars
+* lotNumber obeys vc-should-not-include-string-lot
 * lotNumber ^short = "String representing lot number like `0123L45A`"
 * lotNumber ^definition = "Lot number of the vaccine product. Implementers SHOULD NOT include text synonymous with \"lot number\" in this element as this is redundant. For example, use `0123L45A` rather than `Lot # 0123L45A`."
 
@@ -75,7 +75,7 @@ Description: "Defines a profile representing a vaccination for a vaccination cre
 * performer.actor.display MS
 * performer.actor.display 1..1
 * performer.actor.display ^definition = "Organization which was responsible for vaccine administration. Issuers SHOULD provide display name only. This is provided to Verifiers in case of invalid data in the credential, to support manual validation. This is not expected to be a computable Organization identifier."
-* performer.actor.display obeys should-be-under-20-chars
+* performer.actor.display obeys vc-should-be-under-20-chars
 
 * status ^short = "Whether or not the vaccination was completed"
 * status MS
@@ -115,7 +115,7 @@ Verifiers SHALL assume that if an Immunization resource is provided and `isSubpo
 This element is therefore an exception to the guidance that Issuers must populate `MustSupport` elements if the data are available. An invariant is used to provide a computable representation of this exception: it will produce an error if `isSubpotent = false`, which is the expected value of this element for the vast majority of resources. Because full potency is implicit per this element's definition, we do not want to populate `isSubpotent` with `false` because it increases payload size without adding information.
 
 If `isSubpotent` was not allowed at all (`0..0` cardinality), the concern is that resources where `isSubpotent = true` would inadvertently be generated without any indication they were not potent."
-* isSubpotent obeys shall-be-true-if-populated-invariant
+* isSubpotent obeys vc-shall-be-true-if-populated-invariant
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -185,7 +185,7 @@ we wanted to have value sets corresponding to all the value sets in the IIS core
 profile, VaccinationCredentialVaccineReactionValueSet includes the IIS adverse reaction codes."
 * ^status = #draft
 
-* id obeys should-be-under-20-chars
+* id obeys vc-should-be-under-20-chars
 
 * code = SCT#293104008 "Vaccines adverse reaction (disorder)"
 

--- a/src/test/resources/observation-status-shall-be-complete.test.json
+++ b/src/test/resources/observation-status-shall-be-complete.test.json
@@ -1,0 +1,32 @@
+{
+  "resourceType": "Observation",
+  "meta": {
+    "security": [{ "code": "IAL1" }]
+  },
+  "status": "preliminary",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "94558-4"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "resource:0"
+  },
+  "effectiveDateTime": "2021-02-17",
+  "valueCodeableConcept": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "260373001"
+      }
+    ]
+  },
+  "performer": [
+    {
+      "display": "ABC General Hospital"
+    }
+  ]
+}

--- a/src/test/resources/tests_errors.csv
+++ b/src/test/resources/tests_errors.csv
@@ -1,2 +1,3 @@
 example,profile,expectedIssueSeverity,expectedLocation,expectedErrorMessage
-examples/Scenario1Bundle.json,http://hl7.org/fhir/uv/smarthealthcards-vaccination/StructureDefinition/vaccination-credential-bundle,WARNING,Bundle.id,should-be-omitted
+examples/Scenario1Bundle.json,http://hl7.org/fhir/uv/smarthealthcards-vaccination/StructureDefinition/vaccination-credential-bundle,WARNING,Bundle.id,vc-should-be-omitted
+src/test/resources/observation-status-shall-be-complete.test.json,http://hl7.org/fhir/uv/smarthealthcards-vaccination/StructureDefinition/covid19-laboratory-result-observation,ERROR,,observation-status-shall-be-complete


### PR DESCRIPTION
Updated invariant for lab status at bundle level and resource level. Added test for lab status invariant. Also added prefix vci- to all invariants to match pattern used in other profiles and allow aggregated view in the HTML.