### PR TITLE
update validator version, remove fixed ignored error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <org.hl7.fhir.validation.version>5.3.9</org.hl7.fhir.validation.version>
+    <org.hl7.fhir.validation.version>5.3.11</org.hl7.fhir.validation.version>
   </properties>
 
   <dependencies>

--- a/src/test/java/dvci/vaccinecredentialig/ProfileTest.java
+++ b/src/test/java/dvci/vaccinecredentialig/ProfileTest.java
@@ -135,9 +135,7 @@ public class ProfileTest {
         .getDetails()
         .getText()
         .equalsIgnoreCase(
-          "Relative URLs must be of the format [ResourceName]/[id].  Encountered resource:0") 
-      || issue.getDetails().getText()
-        .equalsIgnoreCase("Resource requires an id, but none is present");
+          "Relative URLs must be of the format [ResourceName]/[id].  Encountered resource:0");
   }
 
   private boolean findImmunizationError(OperationOutcome outcome) {


### PR DESCRIPTION
Updated validator version from 5.3.9 to 5.3.11, which removes "Resource requires an id, but none is present" error for entries in Bundles with type 'collection'.
