### PR TITLE
add exception for observation known validator errors

### DIFF
--- a/src/test/java/dvci/vaccinecredentialig/ProfileTest.java
+++ b/src/test/java/dvci/vaccinecredentialig/ProfileTest.java
@@ -118,7 +118,14 @@ public class ProfileTest {
             "Bundle.entry:vaccinationCredentialImmunization: minimum required = 1, but only found 0"
             )) {
           // if there is an Immunization entry with errors, then ignore this error
-          if (!findImmunizationError(outcome)) {
+          if (!findIgnoredError(outcome, "Immunization")) {
+            errors.add(issue);
+          }
+        } else if (issue.getDetails().getText().contains(
+            "Bundle.entry:laboratoryResultObservation: minimum required = 1, but only found 0"
+          )) {
+          // if there is an Observation entry with errors, then ignore this error
+          if (!findIgnoredError(outcome, "Observation")) {
             errors.add(issue);
           }
         } else if (!ignoreError(issue)) {
@@ -138,13 +145,13 @@ public class ProfileTest {
           "Relative URLs must be of the format [ResourceName]/[id].  Encountered resource:0");
   }
 
-  private boolean findImmunizationError(OperationOutcome outcome) {
-    // find error entry for Immunization resource type that has an ignored error
+  private boolean findIgnoredError(OperationOutcome outcome, String resourceType) {
+    // true if there is an ignored error entry for specific resource type
     for (OperationOutcomeIssueComponent issue : outcome.getIssue()) {
       if (issue.getSeverity().equals(IssueSeverity.ERROR)) {
         if (issue.getExpression()
             .stream()
-            .anyMatch(s -> s.asStringValue().contains("resource.ofType(Immunization)"))) {
+            .anyMatch(s -> s.asStringValue().contains("resource.ofType(" + resourceType + ")"))) {
           if (ignoreError(issue)) {
             return true;
           }

--- a/src/test/java/dvci/vaccinecredentialig/ProfileTest.java
+++ b/src/test/java/dvci/vaccinecredentialig/ProfileTest.java
@@ -113,24 +113,9 @@ public class ProfileTest {
     // manually filter out errors that are due to validator inconsistencies
     ArrayList<OperationOutcomeIssueComponent> errors = new ArrayList<>();
     for (OperationOutcomeIssueComponent issue : outcome.getIssue()) {
-      if (issue.getSeverity().equals(IssueSeverity.ERROR)) {
-        if (issue.getDetails().getText().contains(
-            "Bundle.entry:vaccinationCredentialImmunization: minimum required = 1, but only found 0"
-            )) {
-          // if there is an Immunization entry with errors, then ignore this error
-          if (!findIgnoredError(outcome, "Immunization")) {
-            errors.add(issue);
-          }
-        } else if (issue.getDetails().getText().contains(
-            "Bundle.entry:laboratoryResultObservation: minimum required = 1, but only found 0"
-          )) {
-          // if there is an Observation entry with errors, then ignore this error
-          if (!findIgnoredError(outcome, "Observation")) {
-            errors.add(issue);
-          }
-        } else if (!ignoreError(issue)) {
-          errors.add(issue);
-        }
+      if (issue.getSeverity().equals(IssueSeverity.ERROR)
+          && !ignoreError(issue)) {
+        errors.add(issue);
       }
     }
 
@@ -143,22 +128,6 @@ public class ProfileTest {
         .getText()
         .equalsIgnoreCase(
           "Relative URLs must be of the format [ResourceName]/[id].  Encountered resource:0");
-  }
-
-  private boolean findIgnoredError(OperationOutcome outcome, String resourceType) {
-    // true if there is an ignored error entry for specific resource type
-    for (OperationOutcomeIssueComponent issue : outcome.getIssue()) {
-      if (issue.getSeverity().equals(IssueSeverity.ERROR)) {
-        if (issue.getExpression()
-            .stream()
-            .anyMatch(s -> s.asStringValue().contains("resource.ofType(" + resourceType + ")"))) {
-          if (ignoreError(issue)) {
-            return true;
-          }
-        }
-      }
-    }
-    return false;
   }
 
   private String createMessage(OperationOutcomeIssueComponent issue) {


### PR DESCRIPTION
There is an existing manual filter to ignore profile validation errors for immunizations in bundles that are due to known validator issues (particularly id required). Edit: removed this exception since the error that was caused by required id is now fixed.