### PR TITLE
add valueQuantity to lab DM rules to fix validation issue

### DIFF
--- a/input/fsh/profiles_lab.fsh
+++ b/input/fsh/profiles_lab.fsh
@@ -145,6 +145,7 @@ RuleSet: LaboratoryResultObservationDM
 * performer.type 0..0
 * performer.identifier 0..0
 * valueCodeableConcept.text 0..0
+* valueQuantity.id 0..0
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/test/resources/observation-quantity-dm.test.json
+++ b/src/test/resources/observation-quantity-dm.test.json
@@ -1,0 +1,38 @@
+{
+  "resourceType": "Observation",
+  "meta": {
+    "security": [{"system": "https://smarthealth.cards/ial", "code": "IAL2"}]
+  },
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "94311-8"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "resource:0"
+  },
+  "effectiveDateTime": "2021-02-17",
+  "valueQuantity": {
+    "value": 122,
+    "unit": "umol/L"
+  },
+  "referenceRange": [
+    {
+      "low": {
+        "value": 64
+      },
+      "high": {
+        "value": 104
+      }
+    }
+  ],
+  "performer": [
+    {
+      "display": "ABC General Hospital"
+    }
+  ]
+}

--- a/src/test/resources/tests.csv
+++ b/src/test/resources/tests.csv
@@ -5,3 +5,4 @@ examples/Scenario2Bundle.json,http://hl7.org/fhir/uv/smarthealthcards-vaccinatio
 examples/Scenario2Bundle.json,http://hl7.org/fhir/uv/smarthealthcards-vaccination/StructureDefinition/vaccination-credential-bundle-dm
 examples/Scenario3Bundle.json,http://hl7.org/fhir/uv/smarthealthcards-vaccination/StructureDefinition/covid19-laboratory-bundle
 examples/Scenario3Bundle.json,http://hl7.org/fhir/uv/smarthealthcards-vaccination/StructureDefinition/covid19-laboratory-bundle-dm
+src/test/resources/observation-quantity-dm.test.json,http://hl7.org/fhir/uv/smarthealthcards-vaccination/StructureDefinition/covid19-laboratory-result-observation-dm


### PR DESCRIPTION
This seems like an arbitrary change but is technically ok and it removes validation errors for labs with quantity against DM profiles. Original error can be demonstrated by reverting change in profiles_lab.fsh and running tests.